### PR TITLE
Minor optimizations on static_er_conf, startup script and threadpool size

### DIFF
--- a/bin/roll_pair/egg_pair_bootstrap.sh
+++ b/bin/roll_pair/egg_pair_bootstrap.sh
@@ -114,7 +114,8 @@ else
   PYTHON=${venv}/bin/python
 fi
 
-export PYTHONPATH=$PYTHONPATH:${pythonpath}
+export PYTHONPATH=${pythonpath}
+echo "PYTHONPATH: ${PYTHONPATH}"
 cmd="${PYTHON} ${filepath} --config ${config} --session-id ${session_id} --server-node-id ${server_node_id} --cluster-manager ${cluster_manager_host}:${cluster_manager_port} --node-manager ${node_manager_port} --processor-id ${processor_id}"
 
 if [[ -n ${port} ]]; then

--- a/python/eggroll/core/client.py
+++ b/python/eggroll/core/client.py
@@ -23,6 +23,7 @@ from eggroll.core.command.commands import MetadataCommands, NodeManagerCommands,
     SessionCommands
 from eggroll.core.conf_keys import ClusterManagerConfKeys, NodeManagerConfKeys
 from eggroll.core.constants import SerdesTypes
+from eggroll.core.constants import static_er_conf
 from eggroll.core.grpc.factory import GrpcChannelFactory
 from eggroll.core.meta_model import ErEndpoint, ErServerNode, ErServerCluster, \
     ErProcessor, ErProcessorBatch
@@ -82,8 +83,8 @@ class CommandClient(object):
 class ClusterManagerClient(object):
 
     def __init__(self, options={}):
-        self.__endpoint = ErEndpoint(options.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST, '127.0.0.1'),
-                                     int(options.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT, '4670')))
+        self.__endpoint = ErEndpoint(options.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST, static_er_conf.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST, '127.0.0.1')),
+                                     int(options.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT, static_er_conf.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT, '4670'))))
         if 'serdes_type' in options:
             self.__serdes_type = options['serdes_type']
         else:

--- a/python/eggroll/core/client.py
+++ b/python/eggroll/core/client.py
@@ -23,13 +23,13 @@ from eggroll.core.command.commands import MetadataCommands, NodeManagerCommands,
     SessionCommands
 from eggroll.core.conf_keys import ClusterManagerConfKeys, NodeManagerConfKeys
 from eggroll.core.constants import SerdesTypes
-from eggroll.core.constants import static_er_conf
 from eggroll.core.grpc.factory import GrpcChannelFactory
 from eggroll.core.meta_model import ErEndpoint, ErServerNode, ErServerCluster, \
     ErProcessor, ErProcessorBatch
 from eggroll.core.meta_model import ErStore, ErSessionMeta
 from eggroll.core.proto import command_pb2_grpc
 from eggroll.core.utils import _to_proto_string, _map_and_listify
+from eggroll.core.utils import get_static_er_conf
 from eggroll.core.utils import time_now
 from eggroll.utils.log_utils import get_logger
 
@@ -83,6 +83,7 @@ class CommandClient(object):
 class ClusterManagerClient(object):
 
     def __init__(self, options={}):
+        static_er_conf = get_static_er_conf()
         self.__endpoint = ErEndpoint(options.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST, static_er_conf.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST, '127.0.0.1')),
                                      int(options.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT, static_er_conf.get(ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT, '4670'))))
         if 'serdes_type' in options:

--- a/python/eggroll/core/conf_keys.py
+++ b/python/eggroll/core/conf_keys.py
@@ -13,10 +13,13 @@
 #  limitations under the License.
 
 
-
-
 class CoreConfKeys(object):
+    LOGS_DIR = "eggroll.logs.dir"
+    DATA_DIR = "eggroll.data.dir"
     STATIC_CONF_PATH = "eggroll.static.conf.path"
+    BOOTSTRAP_ROOT_SCRIPT = "eggroll.bootstrap.root.script"
+    BOOTSTRAP_SHELL = "eggroll.bootstrap.shell"
+    BOOTSTRAP_SHELL_ARGS = "eggroll.bootstrap.shell.args"
     CONFKEY_CORE_GRPC_CHANNEL_CACHE_EXPIRE_SEC = "eggroll.core.grpc.channel.cache.expire.sec"
     CONFKEY_CORE_GRPC_CHANNEL_CACHE_SIZE = "eggroll.core.grpc.channel.cache.size"
     CONFKEY_CORE_GRPC_CHANNEL_EXECUTOR_POOL_SIZE = "eggroll.core.grpc.channel.executor.pool.size"

--- a/python/eggroll/core/constants.py
+++ b/python/eggroll/core/constants.py
@@ -13,6 +13,9 @@
 #  limitations under the License.
 
 
+static_er_conf = {}
+
+
 class SerdesTypes(object):
     PROTOBUF = 'PROTOBUF'
     PICKLE = 'PICKLE'

--- a/python/eggroll/core/constants.py
+++ b/python/eggroll/core/constants.py
@@ -13,9 +13,6 @@
 #  limitations under the License.
 
 
-static_er_conf = {}
-
-
 class SerdesTypes(object):
     PROTOBUF = 'PROTOBUF'
     PICKLE = 'PICKLE'

--- a/python/eggroll/core/session.py
+++ b/python/eggroll/core/session.py
@@ -21,8 +21,8 @@ from eggroll.core.constants import SessionStatus, ProcessorTypes
 from eggroll.core.meta_model import ErSessionMeta, \
     ErPartition
 from eggroll.core.utils import get_self_ip, time_now, DEFAULT_DATETIME_FORMAT
+from eggroll.core.utils import get_static_er_conf, set_static_er_conf
 from eggroll.utils.log_utils import get_logger
-from eggroll.core.constants import static_er_conf
 
 L = get_logger()
 
@@ -52,12 +52,12 @@ class ErSession(object):
         if "EGGROLL_DEBUG" not in os.environ:
             os.environ['EGGROLL_DEBUG'] = "0"
 
-        global static_er_conf
+        static_er_conf = get_static_er_conf()
         if not static_er_conf:
             conf_path = options.get(CoreConfKeys.STATIC_CONF_PATH, f"{self.__eggroll_home}/conf/eggroll.properties")
             configs = configparser.ConfigParser()
             configs.read(conf_path)
-            static_er_conf = configs['eggroll']
+            set_static_er_conf(configs['eggroll'])
 
         self.__is_standalone = options.get(SessionConfKeys.CONFKEY_SESSION_DEPLOY_MODE, "") == "standalone"
         if self.__is_standalone and os.name != 'nt':

--- a/python/eggroll/core/session.py
+++ b/python/eggroll/core/session.py
@@ -11,9 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import configparser
 import os
 
 from eggroll.core.client import ClusterManagerClient
+from eggroll.core.conf_keys import CoreConfKeys
 from eggroll.core.conf_keys import SessionConfKeys
 from eggroll.core.constants import SessionStatus, ProcessorTypes
 from eggroll.core.meta_model import ErSessionMeta, \
@@ -42,12 +44,19 @@ class ErSession(object):
         self._cluster_manager_client = ClusterManagerClient(options=options)
         self._table_recorder = None
 
-        if "EGGROLL_DEBUG" not in os.environ:
-            os.environ['EGGROLL_DEBUG'] = "0"
-
         self.__eggroll_home = os.getenv('EGGROLL_HOME', None)
         if not self.__eggroll_home:
             raise EnvironmentError('EGGROLL_HOME is not set')
+
+        if "EGGROLL_DEBUG" not in os.environ:
+            os.environ['EGGROLL_DEBUG'] = "0"
+
+        global static_er_conf
+        if not static_er_conf:
+            conf_path = options.get(CoreConfKeys.STATIC_CONF_PATH, f"{self.__eggroll_home}/conf/eggroll.properties")
+            configs = configparser.ConfigParser()
+            configs.read(conf_path)
+            static_er_conf = configs['eggroll']
 
         self.__is_standalone = options.get(SessionConfKeys.CONFKEY_SESSION_DEPLOY_MODE, "") == "standalone"
         if self.__is_standalone and os.name != 'nt':

--- a/python/eggroll/core/session.py
+++ b/python/eggroll/core/session.py
@@ -22,6 +22,7 @@ from eggroll.core.meta_model import ErSessionMeta, \
     ErPartition
 from eggroll.core.utils import get_self_ip, time_now, DEFAULT_DATETIME_FORMAT
 from eggroll.utils.log_utils import get_logger
+from eggroll.core.constants import static_er_conf
 
 L = get_logger()
 

--- a/python/eggroll/core/transfer/transfer_service.py
+++ b/python/eggroll/core/transfer/transfer_service.py
@@ -121,7 +121,9 @@ class GrpcTransferServicer(transfer_pb2_grpc.TransferServiceServicer):
                 inited = True
 
             broker.put(request)
-
+        if not broker:
+            L.debug("empty requests")
+            return transfer_pb2.TransferBatch()
         broker.signal_write_finish()
         print('GrpcTransferServicer stream finished. tag: ', base_tag, ', remaining write count: ', broker,broker.__dict__)
         return transfer_pb2.TransferBatch(header=response_header)
@@ -129,7 +131,7 @@ class GrpcTransferServicer(transfer_pb2_grpc.TransferServiceServicer):
     @_exception_logger
     def recv(self, request, context):
         base_tag = request.header.tag
-        print('GrpcTransferServicer send broker tag: ', base_tag)
+        print('GrpcTransferServicer recv broker tag: ', base_tag)
         callee_messages_broker = TransferService.get_broker(base_tag)
         import types
         if isinstance(callee_messages_broker, types.GeneratorType):

--- a/python/eggroll/core/utils.py
+++ b/python/eggroll/core/utils.py
@@ -87,7 +87,7 @@ def _exception_logger(func):
 
     return wrapper
 
-DEFAULT_DATETIME_FORMAT = '%Y%m%dT.%H%M%S.%f'
+DEFAULT_DATETIME_FORMAT = '%Y%m%d.%H%M%S.%f'
 def time_now(format: str = DEFAULT_DATETIME_FORMAT):
     formatted = datetime.now().strftime(format)
     if format == DEFAULT_DATETIME_FORMAT or ('%f' in format):

--- a/python/eggroll/core/utils.py
+++ b/python/eggroll/core/utils.py
@@ -21,6 +21,20 @@ from eggroll.utils import log_utils
 
 L = log_utils.get_logger()
 
+static_er_conf = {}
+
+
+def set_static_er_conf(a_dict):
+    global static_er_conf
+    if static_er_conf:
+        raise ValueError('static_er_conf has already been set')
+    static_er_conf = a_dict
+
+
+def get_static_er_conf():
+    return static_er_conf
+
+
 def _to_proto(rpc_message):
     if rpc_message is not None:
         return rpc_message.to_proto()

--- a/python/eggroll/roll_pair/egg_pair.py
+++ b/python/eggroll/roll_pair/egg_pair.py
@@ -40,6 +40,7 @@ from eggroll.core.transfer.transfer_service import GrpcTransferServicer, \
     TransferClient, TransferService
 from eggroll.core.utils import _exception_logger
 from eggroll.core.utils import hash_code
+from eggroll.core.utils import set_static_er_conf
 from eggroll.roll_pair import create_adapter, create_serdes
 from eggroll.roll_pair.transfer_pair import TransferPair
 from eggroll.roll_pair.utils.pair_utils import generator, partitioner, \
@@ -515,7 +516,7 @@ if __name__ == '__main__':
         print(f'reading default config: {conf_file}')
 
     configs.read(conf_file)
-    static_er_conf = configs['eggroll']
+    set_static_er_conf(configs['eggroll'])
     if configs:
         if not args.data_dir:
             args.data_dir = configs['eggroll']['eggroll.data.dir']

--- a/python/eggroll/roll_pair/egg_pair.py
+++ b/python/eggroll/roll_pair/egg_pair.py
@@ -429,7 +429,7 @@ def serve(args):
         transfer_pb2_grpc.add_TransferServiceServicer_to_server(transfer_servicer,
                                                                 transfer_server)
     else:
-        transfer_server = grpc.server(futures.ThreadPoolExecutor(max_workers=5),
+        transfer_server = grpc.server(futures.ThreadPoolExecutor(max_workers=5000),
                                       options=[
                                           (cygrpc.ChannelArgKey.max_send_message_length, -1),
                                           (cygrpc.ChannelArgKey.max_receive_message_length, -1)])

--- a/python/eggroll/roll_pair/egg_pair.py
+++ b/python/eggroll/roll_pair/egg_pair.py
@@ -515,6 +515,7 @@ if __name__ == '__main__':
         print(f'reading default config: {conf_file}')
 
     configs.read(conf_file)
+    static_er_conf = configs['eggroll']
     if configs:
         if not args.data_dir:
             args.data_dir = configs['eggroll']['eggroll.data.dir']

--- a/python/eggroll/roll_pair/test/roll_pair_test_assets.py
+++ b/python/eggroll/roll_pair/test/roll_pair_test_assets.py
@@ -77,8 +77,8 @@ def  get_standalone_context():
 
 def get_cluster_context(cm_host=None, cm_port=None):
     options = {}
-    options[ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST] = cm_host if cm_host else "localhost"
-    options[ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT] = cm_port if cm_port else "4670"
+    #options[ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_HOST] = cm_host if cm_host else "localhost"
+    #options[ClusterManagerConfKeys.CONFKEY_CLUSTER_MANAGER_PORT] = cm_port if cm_port else "4670"
 
     session = ErSession(options=options)
     print(session.get_session_id())

--- a/python/eggroll/roll_pair/test/test_interface.py
+++ b/python/eggroll/roll_pair/test/test_interface.py
@@ -20,10 +20,10 @@ from eggroll.roll_pair.test.roll_pair_test_assets import get_debug_test_context,
     get_cluster_context, get_standalone_context, set_default_option, \
     get_default_options
 
-is_debug = bool(os.environ.get("EGGROLL_STANDALONE_DEBUG", "True"))
+is_debug = os.environ.get("EGGROLL_STANDALONE_DEBUG", "false").lower() in ("t", "true", "yes", "y", 1)
 is_standalone = False
 # cm_host="172.16.153.19"
-cm_host = "127.0.0.1"
+#cm_host = "127.0.0.1"
 # cm_port="4680"
 cm_port = "4670"
 total_partitions = 1
@@ -56,7 +56,7 @@ class TestStandalone(unittest.TestCase):
             if is_standalone:
                 cls.ctx = get_standalone_context()
             else:
-                cls.ctx = get_cluster_context(cm_host, cm_port)
+                cls.ctx = get_cluster_context()
         set_default_option('include_key', False)
         set_default_option('total_partitions', total_partitions)
 

--- a/python/eggroll/roll_pair/test/test_interface.py
+++ b/python/eggroll/roll_pair/test/test_interface.py
@@ -13,18 +13,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
 import unittest
 
 from eggroll.roll_pair.test.roll_pair_test_assets import get_debug_test_context, \
     get_cluster_context, get_standalone_context, set_default_option, \
     get_default_options
-import os
-is_debug = os.environ.get("EGGROLL_STANDALONE_DEBUG", True)
+
+is_debug = bool(os.environ.get("EGGROLL_STANDALONE_DEBUG", "True"))
 is_standalone = False
 # cm_host="172.16.153.19"
-cm_host="127.0.0.1"
+cm_host = "127.0.0.1"
 # cm_port="4680"
-cm_port="4670"
+cm_port = "4670"
 total_partitions = 1
 
 

--- a/python/eggroll/roll_pair/test/test_performance.py
+++ b/python/eggroll/roll_pair/test/test_performance.py
@@ -1,0 +1,87 @@
+#  Copyright (c) 2019 - now, Eggroll Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+import time
+import unittest
+
+
+def kv_generator(limit, data_size):
+    s = 'a' * data_size
+
+    for i in range(limit):
+        yield i, s
+
+
+class TestPerformance(unittest.TestCase):
+    namespace = "test_performance"
+    name = "4G"
+    name_r = name + "_r"
+    partition = 60
+    table = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+
+        # todo: get context
+        eggroll.init('test_performance', 1)
+        cls.table = eggroll.table(cls.name, cls.namespace, partition=cls.partition)
+        cls.table_r = eggroll.table(cls.name_r, cls.namespace, partition=cls.partition)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # todo: stop session
+        eggroll.stop()
+
+    def setUp(self) -> None:
+        self.start_time = time.time()
+
+    def tearDown(self) -> None:
+        t = time.time() - self.start_time
+        print(f"time used: {t}")
+
+    def test_put_all(self):
+        self.table.destroy()
+        self.table = eggroll.table(cls.name, cls.namespace, partition=cls.partition)
+        self.table.put_all(kv_generator(1024 * 1024, 4000))
+        print(f"put all count: {self.table.count()}")
+
+    def test_map_values(self):
+        b = self.table.mapValues(lambda v : v[1:] + v[0])
+        print(f"map_values count: {b.count()}")
+
+    def test_map(self):
+        b = self.table.map(lambda k, v : k + 100, v[1:] + v[0])
+        print(f"map count: {b.count()}")
+
+    def test_reduce(self):
+        b = self.table.reduce(lambda l, r : l)
+        print(f"reduce result: {b}")
+
+    def prepare_join(self):
+        self.table_r.destroy()
+        self.table_r = eggroll.table(self.name_r, self.namespace, partition=self.partition)
+        self.table.put_all(kv_generator(1024 * 1024, 4000))
+        print(f"prepare join result: {self.table_r.count()}")
+
+    def test_join(self):
+        b = self.table.join(self.table_r, lambda v1, v2 : v1[1000:] + v2[0:1000])
+        print(f"join count: {b.count()}")
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestPerformance)
+    unittest.TextTestRunner(verbosity=0).run(suite)
+

--- a/python/eggroll/roll_pair/transfer_pair.py
+++ b/python/eggroll/roll_pair/transfer_pair.py
@@ -96,7 +96,7 @@ class TransferPair(object):
     def __init__(self, transfer_id: str):
         # params from __init__ params
         self.__transfer_id = transfer_id
-        self._executor_pool = ThreadPoolExecutor(max_workers=100)
+        self._executor_pool = ThreadPoolExecutor(max_workers=5000)
 
     def __generate_tag(self, partition_id):
         return generate_task_id(job_id=self.__transfer_id, partition_id=partition_id)
@@ -131,6 +131,7 @@ class TransferPair(object):
         return CompositeFuture(futures)
 
     @staticmethod
+    @_exception_logger
     def pair_to_bin_batch(input_iter, buffer_size=32 * 1024 * 1024):
         import os
         buffer_size = int(os.environ.get("EGGROLL_ROLLPAIR_BIN_BATCH_SIZE", buffer_size))


### PR DESCRIPTION
1. Introduced static_er_conf in python, which similar to scala.
2. Optimized startup scripts to remove PYTHONPATH in env.
3. Bumped threadpool size.
4. Add default connection conf in a default conf located in ${EGGROLL_HOME}/conf/eggroll.properties.