### PR TITLE
Feature 2.0 core

### DIFF
--- a/jvm/core/main/java/com/webank/eggroll/core/factory/GrpcChannelFactory.java
+++ b/jvm/core/main/java/com/webank/eggroll/core/factory/GrpcChannelFactory.java
@@ -138,9 +138,9 @@ public class GrpcChannelFactory {
     int channelFlowControlWindow = StaticErConf
         .getInt(CoreConfKeys.CONFKEY_CORE_GRPC_CHANNEL_FLOW_CONTROL_WINDOW(), 16 << 20);
     int channelMaxInboundMessageSize = StaticErConf
-        .getInt(CoreConfKeys.CONFKEY_CORE_GRPC_CHANNEL_MAX_INBOUND_MESSAGE_SIZE(), 32 << 20);
+        .getInt(CoreConfKeys.CONFKEY_CORE_GRPC_CHANNEL_MAX_INBOUND_MESSAGE_SIZE(), 2 << 30 - 1);
     int channelMaxInboundMetadataSize = StaticErConf
-        .getInt(CoreConfKeys.CONFKEY_CORE_GRPC_CHANNEL_MAX_INBOUND_METADATA_SIZE(), 64 << 10);
+        .getInt(CoreConfKeys.CONFKEY_CORE_GRPC_CHANNEL_MAX_INBOUND_METADATA_SIZE(), 64 << 20);
     long channelRetryBufferSize = StaticErConf
         .getLong(CoreConfKeys.CONFKEY_CORE_GRPC_CHANNEL_RETRY_BUFFER_SIZE(), 16 << 20);
     int channelMaxRetryAttempts = StaticErConf

--- a/jvm/core/main/scala/com/webank/eggroll/core/error/CommandExceptions.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/error/CommandExceptions.scala
@@ -25,6 +25,6 @@ class CommandRoutingException(serviceName: String, cause: Throwable)
   extends RuntimeException(s"[COMMANDROUTING] Failed to route to serviceName ${serviceName}", cause)
 
 class CommandCallException(serviceName: String, endpoint: ErEndpoint, cause: Throwable)
-  extends RuntimeException(s"[COMMANDCALL] Failed to call to serviceName: ${serviceName} to endpoint: ${endpoint}", cause) {
+  extends RuntimeException(s"[COMMANDCALL] Error while calling serviceName: ${serviceName} to endpoint: ${endpoint}", cause) {
   def this(commandUri: CommandURI, endpoint: ErEndpoint, cause: Throwable) = this(commandUri.uriString, endpoint, cause)
 }

--- a/jvm/core/main/scala/com/webank/eggroll/core/meta/TransferModel.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/meta/TransferModel.scala
@@ -34,17 +34,17 @@ case class ErTransferHeader(id: Int, tag: String, totalSize: Long, status: Strin
 
 case class ErTransferBatch(header: ErTransferHeader, data: Array[Byte]) extends TransferRpcMessage
 
-case class ErFederationHeader(federationSessionId: String,
-                              name: String,
-                              tag: String,
-                              srcRole: String,
-                              srcPartyId: String,
-                              dstRole: String,
-                              dstPartyId: String,
-                              dataType: String,
-                              options: Map[String, String]) extends TransferRpcMessage {
+case class ErRollSiteHeader(rollSiteSessionId: String,
+                            name: String,
+                            tag: String,
+                            srcRole: String,
+                            srcPartyId: String,
+                            dstRole: String,
+                            dstPartyId: String,
+                            dataType: String,
+                            options: Map[String, String]) extends TransferRpcMessage {
   def concat(delim: String = StringConstants.HASH, prefix: Array[String] = Array("__federation__")): String = {
-    val finalArray = prefix ++ Array(federationSessionId, name, tag, srcRole, srcPartyId, dstRole, dstPartyId)
+    val finalArray = prefix ++ Array(rollSiteSessionId, name, tag, srcRole, srcPartyId, dstRole, dstPartyId)
     String.join(delim, finalArray: _*)
   }
 }
@@ -81,10 +81,10 @@ object TransferModelPbMessageSerdes {
       baseSerializable.asInstanceOf[ErTransferBatch].toBytes()
   }
 
-  implicit class ErFederationHeaderToPbMessage(src: ErFederationHeader) extends PbMessageSerializer {
-    override def toProto[T >: Message](): Transfer.FederationHeader = {
-      val builder = Transfer.FederationHeader.newBuilder()
-        .setFederationSessionId(src.federationSessionId)
+  implicit class ErRollSiteHeaderToPbMessage(src: ErRollSiteHeader) extends PbMessageSerializer {
+    override def toProto[T >: Message](): Transfer.RollSiteHeader = {
+      val builder = Transfer.RollSiteHeader.newBuilder()
+        .setRollSiteSessionId(src.rollSiteSessionId)
         .setName(src.name)
         .setTag(src.tag)
         .setSrcRole(src.srcRole)
@@ -98,7 +98,7 @@ object TransferModelPbMessageSerdes {
     }
 
     override def toBytes(baseSerializable: BaseSerializable): Array[Byte] =
-      baseSerializable.asInstanceOf[ErFederationHeader].toBytes()
+      baseSerializable.asInstanceOf[ErRollSiteHeader].toBytes()
   }
 
   // deserializers
@@ -120,10 +120,10 @@ object TransferModelPbMessageSerdes {
       Transfer.TransferHeader.parseFrom(bytes).fromProto()
   }
 
-  implicit class ErFederationHeaderFromPbMessage(src: Transfer.FederationHeader) extends PbMessageDeserializer {
-    override def fromProto[T >: RpcMessage](): ErFederationHeader = {
-      ErFederationHeader(
-        federationSessionId = src.getFederationSessionId,
+  implicit class ErRollSiteHeaderFromPbMessage(src: Transfer.RollSiteHeader) extends PbMessageDeserializer {
+    override def fromProto[T >: RpcMessage](): ErRollSiteHeader = {
+      ErRollSiteHeader(
+        rollSiteSessionId = src.getRollSiteSessionId,
         name = src.getName,
         tag = src.getTag,
         srcRole = src.getSrcRole,
@@ -135,8 +135,8 @@ object TransferModelPbMessageSerdes {
       )
     }
 
-    override def fromBytes(bytes: Array[Byte]): ErFederationHeader =
-      Transfer.FederationHeader.parseFrom(bytes).fromProto()
+    override def fromBytes(bytes: Array[Byte]): ErRollSiteHeader =
+      Transfer.RollSiteHeader.parseFrom(bytes).fromProto()
   }
 }
 

--- a/jvm/core/main/scala/com/webank/eggroll/core/transfer/TransferClient.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/transfer/TransferClient.scala
@@ -159,7 +159,7 @@ class GrpcKvPackingTransferSendStreamProcessor(clientCallStreamObserver: ClientC
   private val transferHeaderBuilder = Transfer.TransferHeader.newBuilder()
   private val transferBatchBuilder = Transfer.TransferBatch.newBuilder()
   private var directBinPacketBuffer: ByteBuffer = _
-  private val binPacketLength = 1 << 20
+  private val binPacketLength = 32 << 20
   private val bufferElementSize = 100
   private var elementCount = 0
   private val dataBuffer = new util.ArrayList[(Array[Byte], Array[Byte])](bufferElementSize)

--- a/jvm/core/main/scala/com/webank/eggroll/core/transfer/TransferClient.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/transfer/TransferClient.scala
@@ -272,10 +272,14 @@ class TransferSendStreamProcessor(clientCallStreamObserver: ClientCallStreamObse
                                   status: String)
   extends BaseClientCallStreamProcessor[Transfer.TransferBatch](clientCallStreamObserver) {
   override def onProcess(): Unit = {
+    val finalData = if (data != null) data else Array.emptyByteArray
     val batch = ErTransferBatch(
       header = ErTransferHeader(
-        id = 100, tag = this.tag, totalSize = data.size, status = this.status),
-      data = this.data)
+        id = 100,
+        tag = tag,
+        totalSize = finalData.size,
+        status = status),
+      data = finalData)
     clientCallStreamObserver.onNext(batch.toProto())
   }
 }

--- a/jvm/roll_pair/test/scala/com/webank/eggroll/rollpair/io/TestIo.scala
+++ b/jvm/roll_pair/test/scala/com/webank/eggroll/rollpair/io/TestIo.scala
@@ -90,7 +90,7 @@ class TestIo {
     val ctx = new RollPairContext(new ErSession(sid, options=options))
     val rp = ctx.load("ns1","testPutBatch")
 
-    var directBinPacketBuffer: ByteBuffer = ByteBuffer.allocateDirect(1<<10)
+    var directBinPacketBuffer: ByteBuffer = ByteBuffer.allocateDirect(32 << 20)
     directBinPacketBuffer.order(ByteOrder.BIG_ENDIAN)
 
     directBinPacketBuffer.put(NetworkConstants.TRANSFER_PROTOCOL_MAGIC_NUMBER)   // magic num

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/event/listener/PipeHandleNotificationEventListener.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/event/listener/PipeHandleNotificationEventListener.java
@@ -36,6 +36,8 @@ public class PipeHandleNotificationEventListener implements ApplicationListener<
     private static final Logger LOGGER = LogManager.getLogger(PipeHandleNotificationEventListener.class);
     @Autowired
     private ApplicationContext applicationContext;
+//    @Autowired
+//    private ThreadPoolTaskExecutor asyncThreadPool;
 
     @Override
     public void onApplicationEvent(PipeHandleNotificationEvent pipeHandleNotificationEvent) {
@@ -47,6 +49,7 @@ public class PipeHandleNotificationEventListener implements ApplicationListener<
 
         if (pipe instanceof PacketQueuePipe) {
             CascadedCaller cascadedCaller = applicationContext.getBean(CascadedCaller.class, pipeHandlerInfo);
+            //asyncThreadPool.submit(cascadedCaller);
             cascadedCaller.run();
         }
     }

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/event/listener/PipeHandleNotificationEventListener.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/event/listener/PipeHandleNotificationEventListener.java
@@ -16,28 +16,16 @@
 
 package com.webank.eggroll.rollsite.event.listener;
 
-import com.webank.ai.eggroll.api.networking.proxy.Proxy;
-import com.webank.eggroll.core.constant.CoreConfKeys;
-import com.webank.eggroll.core.retry.RetryException;
-import com.webank.eggroll.core.retry.Retryer;
-import com.webank.eggroll.core.retry.factory.AttemptOperations;
-import com.webank.eggroll.core.retry.factory.RetryerBuilder;
-import com.webank.eggroll.core.retry.factory.StopStrategies;
-import com.webank.eggroll.core.retry.factory.WaitTimeStrategies;
-import com.webank.eggroll.core.session.StaticErConf;
 import com.webank.eggroll.core.util.ToStringUtils;
 import com.webank.eggroll.rollsite.event.model.PipeHandleNotificationEvent;
-import com.webank.eggroll.rollsite.event.model.PipeHandleNotificationEvent.Type;
-import com.webank.eggroll.rollsite.grpc.client.DataTransferPipedClient;
 import com.webank.eggroll.rollsite.infra.Pipe;
 import com.webank.eggroll.rollsite.infra.impl.PacketQueuePipe;
 import com.webank.eggroll.rollsite.model.PipeHandlerInfo;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import com.webank.eggroll.rollsite.service.CascadedCaller;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -46,10 +34,33 @@ import org.springframework.stereotype.Component;
 @Scope("prototype")
 public class PipeHandleNotificationEventListener implements ApplicationListener<PipeHandleNotificationEvent> {
     private static final Logger LOGGER = LogManager.getLogger(PipeHandleNotificationEventListener.class);
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void onApplicationEvent(PipeHandleNotificationEvent pipeHandleNotificationEvent) {
+        // LOGGER.warn("event listened: {}", pipeHandleNotificationEvent.getPipeHandlerInfo());
+        LOGGER.info("event metadata: {}", ToStringUtils.toOneLineString(pipeHandleNotificationEvent.getPipeHandlerInfo().getMetadata()));
+
+        PipeHandlerInfo pipeHandlerInfo = pipeHandleNotificationEvent.getPipeHandlerInfo();
+        Pipe pipe = pipeHandlerInfo.getPipe();
+
+        if (pipe instanceof PacketQueuePipe) {
+            CascadedCaller cascadedCaller = applicationContext.getBean(CascadedCaller.class, pipeHandlerInfo);
+            cascadedCaller.run();
+        }
+    }
+}
+
+/*
+@Component
+@Scope("prototype")
+public class PipeHandleNotificationEventListener implements ApplicationListener<PipeHandleNotificationEvent> {
+    private static final Logger LOGGER = LogManager.getLogger(PipeHandleNotificationEventListener.class);
     //@Autowired
     //private ApplicationContext applicationContext;
     @Autowired
-    private DataTransferPipedClient client;
+    private ThreadPoolTaskExecutor asyncThreadPool;
 
     @Override
     public void onApplicationEvent(PipeHandleNotificationEvent pipeHandleNotificationEvent) {
@@ -66,11 +77,13 @@ public class PipeHandleNotificationEventListener implements ApplicationListener<
             Type type = pipeHandlerInfo.getType();
 
             if (PipeHandleNotificationEvent.Type.PUSH == type) {
-                /*
+                */
+/*
                 client.initPush(metadata, pipe);
                 client.doPush();
                 client.completePush();
-                */
+                *//*
+
                 pushStream(metadata, pipe);
 
             } else if (PipeHandleNotificationEvent.Type.PULL == type) {
@@ -124,3 +137,4 @@ public class PipeHandleNotificationEventListener implements ApplicationListener<
         return 0;
     }
 }
+*/

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/GrpcServerFactory.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/GrpcServerFactory.java
@@ -92,8 +92,9 @@ public class GrpcServerFactory {
 
         serverBuilder.addService(dataTransferPipedServer)
                 .addService(routeServer)
-                .maxConcurrentCallsPerConnection(20000).maxInboundMetadataSize(2 << 20)
-                .maxInboundMessageSize(32 << 20)
+                .maxConcurrentCallsPerConnection(20000)
+                .maxInboundMetadataSize(64 << 20)
+                .maxInboundMessageSize(2 << 30 - 1)
                 .flowControlWindow(32 << 20)
                 .keepAliveTime(6, TimeUnit.MINUTES)
                 .keepAliveTimeout(24, TimeUnit.HOURS)

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/GrpcServerFactory.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/GrpcServerFactory.java
@@ -92,7 +92,7 @@ public class GrpcServerFactory {
 
         serverBuilder.addService(dataTransferPipedServer)
                 .addService(routeServer)
-                .maxConcurrentCallsPerConnection(20000)
+                .maxConcurrentCallsPerConnection(20000).maxInboundMetadataSize(2 << 20)
                 .maxInboundMessageSize(32 << 20)
                 .flowControlWindow(32 << 20)
                 .keepAliveTime(6, TimeUnit.MINUTES)

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/ProxyGrpcStubFactory.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/ProxyGrpcStubFactory.java
@@ -191,7 +191,8 @@ public class ProxyGrpcStubFactory {
                 .idleTimeout(1, TimeUnit.HOURS)
                 .perRpcBufferLimit(16 << 20)
                 .flowControlWindow(32 << 20)
-                .maxInboundMessageSize(32 << 20)
+                .maxInboundMessageSize(2 << 30 - 1)
+                .maxInboundMetadataSize(64 << 20)
                 .enableRetry()
                 .retryBufferSize(16 << 20)
                 .maxRetryAttempts(20);      // todo:1: configurable

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/grpc/client/PushStreamProcessor.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/grpc/client/PushStreamProcessor.java
@@ -21,6 +21,7 @@ import com.webank.ai.eggroll.api.networking.proxy.Proxy.Packet;
 import com.webank.eggroll.core.grpc.processor.BaseClientCallStreamProcessor;
 import com.webank.eggroll.rollsite.infra.Pipe;
 import io.grpc.stub.ClientCallStreamObserver;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -114,8 +115,7 @@ public class PushStreamProcessor extends BaseClientCallStreamProcessor<Proxy.Pac
         Proxy.Packet packet = null;
         do {
             //packet = (Proxy.Packet) pipe.read(1, TimeUnit.SECONDS);
-            //packet = (Proxy.Packet) transferBroker.read(1, TimeUnit.SECONDS);
-            packet = (Proxy.Packet) transferBroker.read();
+            packet = (Proxy.Packet) transferBroker.read(1, TimeUnit.SECONDS);
 
             if (packet != null) {
                 Proxy.Metadata outputMetadata = packet.getHeader();

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/grpc/client/PushStreamProcessor.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/grpc/client/PushStreamProcessor.java
@@ -114,6 +114,7 @@ public class PushStreamProcessor extends BaseClientCallStreamProcessor<Proxy.Pac
         Proxy.Packet packet = null;
         do {
             //packet = (Proxy.Packet) pipe.read(1, TimeUnit.SECONDS);
+            //packet = (Proxy.Packet) transferBroker.read(1, TimeUnit.SECONDS);
             packet = (Proxy.Packet) transferBroker.read();
 
             if (packet != null) {
@@ -133,7 +134,7 @@ public class PushStreamProcessor extends BaseClientCallStreamProcessor<Proxy.Pac
                            emptyRetryCount);
                 }
             }
-        } while ((packet != null || !transferBroker.isDrained()) && emptyRetryCount < 30 && !transferBroker.hasError());
+        } while ((packet != null || !transferBroker.isDrained()) && emptyRetryCount < 300 && !transferBroker.hasError());
 
     }
 
@@ -150,7 +151,7 @@ public class PushStreamProcessor extends BaseClientCallStreamProcessor<Proxy.Pac
         //LOGGER.info("[CLUSTERCOMM][PUSHPROCESSOR] actual completes send stream for task: {}, packetCount: {}",
         //           transferMetaString, packetCount);
         // transferBroker.setFinished();
-        transferBroker.close();
+        //transferBroker.close();
         super.onComplete();
     }
 }

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/grpc/observer/ServerPushRequestStreamObserver.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/grpc/observer/ServerPushRequestStreamObserver.java
@@ -235,7 +235,13 @@ public class ServerPushRequestStreamObserver implements StreamObserver<Proxy.Pac
                     }
                 }
 
-                rollSiteUtil.putBatch(value.asReadOnlyByteBuffer());
+                if (value == null) {
+                    IllegalStateException e = new IllegalStateException("value is null for name: " + name);
+                    onError(e);
+                    throw e;
+                }
+
+                rollSiteUtil.putBatch(value);
                 LOGGER.info("end putBatch");
             }
 
@@ -301,6 +307,11 @@ public class ServerPushRequestStreamObserver implements StreamObserver<Proxy.Pac
         long loopEndTimestamp = completionWaitStartTimestamp;
         long waitCount = 0;
 
+        if (inputMetadata == null) {
+            IllegalStateException e = new IllegalStateException("input metadata is null in onComplete");
+            onError(e);
+            throw e;
+        }
         if(proxyServerConf.getPartyId().equals(inputMetadata.getDst().getPartyId())) {
             pipe.setDrained();
             pipe.onComplete();

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/JobStatus.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/JobStatus.java
@@ -3,14 +3,17 @@ package com.webank.eggroll.rollsite.infra;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 // TODO:0: add method to clean the map
 public class JobStatus {
     public static ConcurrentHashMap<String, String> jobIdToSessionId = new ConcurrentHashMap<>();
     private static ConcurrentHashMap<String, CountDownLatch> jobIdToFinishLatch = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<String, AtomicInteger> jobIdToPutBatchCount = new ConcurrentHashMap<>();
     private static ConcurrentHashMap<String, String> tagkeyToObjType = new ConcurrentHashMap<>();
 
     private static final Object latchLock = new Object();
+    private static final Object putBatchLock = new Object();
 
     public static boolean hasLatch(String jobId) {
         return jobIdToFinishLatch.containsKey(jobId);
@@ -27,11 +30,19 @@ public class JobStatus {
         }
     }
 
-    public static void countDownLatch(String jobId) {
+    public static void countDownFinishLatch(String jobId) {
         if (jobIdToFinishLatch.containsKey(jobId)) {
             jobIdToFinishLatch.get(jobId).countDown();
         } else {
             throw new IllegalStateException("jobId " + jobId + " does not exist");
+        }
+    }
+
+    public static long getFinishLatchCount(String jobId) {
+        if (jobIdToFinishLatch.containsKey(jobId)) {
+            return jobIdToFinishLatch.get(jobId).getCount();
+        } else {
+            return Integer.MIN_VALUE;
         }
     }
 
@@ -49,5 +60,31 @@ public class JobStatus {
 
     public static String getType(String name) {
         return tagkeyToObjType.get(name);
+    }
+
+    public static int increasePutBatchCount(String jobId) {
+        if (!jobIdToPutBatchCount.containsKey(jobId)) {
+            synchronized (putBatchLock) {
+                if (!jobIdToPutBatchCount.containsKey(jobId)) {
+                    jobIdToPutBatchCount.put(jobId, new AtomicInteger(0));
+                }
+            }
+        }
+
+        return jobIdToPutBatchCount.get(jobId).incrementAndGet();
+    }
+
+    public static int decreasePutBatchCount(String jobId) {
+        if (jobIdToPutBatchCount.containsKey(jobId)) {
+            return jobIdToPutBatchCount.get(jobId).decrementAndGet();
+        }
+        return Integer.MIN_VALUE;
+    }
+
+    public static int getPutBatchCount(String jobId) {
+        if (jobIdToPutBatchCount.containsKey(jobId)) {
+            return jobIdToPutBatchCount.get(jobId).get();
+        }
+        return Integer.MIN_VALUE;
     }
 }

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/BasePipe.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/BasePipe.java
@@ -68,7 +68,7 @@ public abstract class BasePipe implements Pipe {
     @Override
     public boolean isClosed() {
         if (!closed) {
-            if (writerLatch.getCount() == 0 && isDrained()) {
+            if ((writerLatch == null || writerLatch.getCount() == 0) && isDrained()) {
                 close();
             }
         }

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/PacketQueuePipe.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/PacketQueuePipe.java
@@ -18,25 +18,20 @@ package com.webank.eggroll.rollsite.infra.impl;
 
 
 import com.webank.ai.eggroll.api.networking.proxy.Proxy;
-import com.webank.eggroll.rollsite.factory.QueueFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 @Component
 @Scope("prototype")
 public class PacketQueuePipe extends BasePipe {
     private static final Logger LOGGER = LogManager.getLogger(PacketQueuePipe.class);
-    @Autowired
-    private QueueFactory queueFactory;
+
     private Proxy.Metadata metadata;
-    private LinkedBlockingQueue<Proxy.Packet> queue;
+    private LinkedBlockingQueue<Proxy.Packet> queue = new LinkedBlockingQueue<>(3000);
     private int inCounter = 0;
     private int outCounter = 0;
 
@@ -48,11 +43,6 @@ public class PacketQueuePipe extends BasePipe {
         super();
         // this.queue = queueFactory.createConcurrentLinkedQueue();
         this.metadata = metadata;
-    }
-
-    @PostConstruct
-    private void init() {
-        this.queue = queueFactory.createLinkedBlockingQueue(3000);
     }
 
     @Override

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/RollPairSinkPipe.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/RollPairSinkPipe.java
@@ -20,9 +20,9 @@ package com.webank.eggroll.rollsite.infra.impl;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.webank.eggroll.core.meta.ErFederationHeader;
+import com.webank.eggroll.core.meta.ErRollSiteHeader;
 import com.webank.eggroll.core.meta.TransferModelPbMessageSerdes;
-import com.webank.eggroll.core.transfer.Transfer.FederationHeader;
+import com.webank.eggroll.core.transfer.Transfer.RollSiteHeader;
 import com.webank.eggroll.rollsite.RollSiteUtil;
 import com.webank.eggroll.rollsite.infra.JobStatus;
 import java.nio.charset.StandardCharsets;
@@ -31,14 +31,14 @@ import scala.collection.immutable.Map.Map1;
 
 public class RollPairSinkPipe extends BasePipe {
 
-  private ErFederationHeader erFederationHeader;
+  private ErRollSiteHeader erRollSiteHeader;
   private RollSiteUtil rollSiteUtil;
   private String erSessionId;
   private String rollSiteSessionId;
 
-  public RollPairSinkPipe(ErFederationHeader erFederationHeader) {
-    this.erFederationHeader = erFederationHeader;
-    this.rollSiteSessionId = erFederationHeader.federationSessionId();
+  public RollPairSinkPipe(ErRollSiteHeader erRollSiteHeader) {
+    this.erRollSiteHeader = erRollSiteHeader;
+    this.rollSiteSessionId = erRollSiteHeader.rollSiteSessionId();
 
     try {
       while (!JobStatus.jobIdToSessionId.containsKey(rollSiteSessionId)) {
@@ -49,12 +49,12 @@ public class RollPairSinkPipe extends BasePipe {
     }
 
     this.erSessionId = JobStatus.jobIdToSessionId.get(rollSiteSessionId);
-    this.rollSiteUtil = new RollSiteUtil(erSessionId, erFederationHeader, new Map1<>("", ""));
+    this.rollSiteUtil = new RollSiteUtil(erSessionId, erRollSiteHeader, new Map1<>("", ""));
   }
 
-  public RollPairSinkPipe(String erFederationHeaderString) throws InvalidProtocolBufferException {
-    this(TransferModelPbMessageSerdes.ErFederationHeaderFromPbMessage(
-        FederationHeader.parseFrom(erFederationHeaderString.getBytes(StandardCharsets.ISO_8859_1))).fromProto());
+  public RollPairSinkPipe(String erRollSiteHeaderString) throws InvalidProtocolBufferException {
+    this(TransferModelPbMessageSerdes.ErRollSiteHeaderFromPbMessage(
+        RollSiteHeader.parseFrom(erRollSiteHeaderString.getBytes(StandardCharsets.ISO_8859_1))).fromProto());
   }
 
   @Override

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/RollPairSinkPipe.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/infra/impl/RollPairSinkPipe.java
@@ -65,7 +65,7 @@ public class RollPairSinkPipe extends BasePipe {
   @Override
   public void write(Object o) {
     if (o instanceof ByteString) {
-      this.rollSiteUtil.putBatch(((ByteString) o).asReadOnlyByteBuffer());
+      this.rollSiteUtil.putBatch((ByteString) o);
     } else {
       throw new IllegalArgumentException("Argument must be a ByteString instance");
     }

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/service/CascadedCaller.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/service/CascadedCaller.java
@@ -18,11 +18,24 @@ package com.webank.eggroll.rollsite.service;
 
 import com.google.common.base.Preconditions;
 import com.webank.ai.eggroll.api.networking.proxy.Proxy;
+import com.webank.eggroll.core.constant.CoreConfKeys;
+import com.webank.eggroll.core.retry.RetryException;
+import com.webank.eggroll.core.retry.Retryer;
+import com.webank.eggroll.core.retry.factory.AttemptOperations;
+import com.webank.eggroll.core.retry.factory.RetryerBuilder;
+import com.webank.eggroll.core.retry.factory.StopStrategies;
+import com.webank.eggroll.core.retry.factory.WaitTimeStrategies;
+import com.webank.eggroll.core.session.StaticErConf;
 import com.webank.eggroll.rollsite.event.model.PipeHandleNotificationEvent;
+import com.webank.eggroll.rollsite.event.model.PipeHandleNotificationEvent.Type;
 import com.webank.eggroll.rollsite.grpc.client.DataTransferPipedClient;
 import com.webank.eggroll.rollsite.infra.Pipe;
 import com.webank.eggroll.rollsite.model.PipeHandlerInfo;
-import com.webank.eggroll.rollsite.event.model.PipeHandleNotificationEvent.Type;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.scheduling.annotation.Async;
@@ -35,6 +48,8 @@ public class CascadedCaller implements Runnable {
     private DataTransferPipedClient client;
 
     private PipeHandlerInfo pipeHandlerInfo;
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public CascadedCaller() {
     }
@@ -51,25 +66,58 @@ public class CascadedCaller implements Runnable {
     @Async
     public void run() {
         Preconditions.checkNotNull(pipeHandlerInfo);
-
         Pipe pipe = pipeHandlerInfo.getPipe();
 
         Proxy.Metadata metadata = pipeHandlerInfo.getMetadata();
-        client.initPush(metadata, pipe);
 
-        Type type = pipeHandlerInfo.getType();
+        int result = 0;
+        long fixedWaitTime = StaticErConf
+            .getLong(CoreConfKeys.CONFKEY_CORE_RETRY_DEFAULT_WAIT_TIME_MS(), 10000L);
+        int maxAttempts = StaticErConf
+            .getInt(CoreConfKeys.CONFKEY_CORE_RETRY_DEFAULT_MAX_ATTEMPTS(), 10);
+        long attemptTimeout = StaticErConf
+            .getLong(CoreConfKeys.CONFKEY_CORE_RETRY_DEFAULT_ATTEMPT_TIMEOUT_MS(), 30000L);
 
-        if (PipeHandleNotificationEvent.Type.PUSH == type) {
-            //client.push(metadata, pipe);
-            //if(metadata.getDst() == metadata.getSrc())
-            //    return;
-            client.doPush();
-            //pipe.onComplete();
-            client.completePush();
-        } else if (PipeHandleNotificationEvent.Type.PULL == type) {
-            client.pull(metadata, pipe);
-        } else {
-            client.unaryCall(pipeHandlerInfo.getPacket(), pipe);
+        // TODO:0: configurable
+        Retryer<Integer> retryer = RetryerBuilder.<Integer>newBuilder()
+            .withWaitTimeStrategy(WaitTimeStrategies.fixedWaitTime(fixedWaitTime))
+            .withStopStrategy(StopStrategies.stopAfterMaxAttempt(maxAttempts))
+            .withAttemptOperation(
+                AttemptOperations.<Integer>fixedTimeLimit(attemptTimeout, TimeUnit.MINUTES))
+            .retryIfAnyException()
+            .build();
+
+        final Callable<Integer> pushStreamRetry = () -> {
+            client.initPush(metadata, pipe);
+
+            Type type = pipeHandlerInfo.getType();
+
+            if (PipeHandleNotificationEvent.Type.PUSH == type) {
+                //client.push(metadata, pipe);
+                //if(metadata.getDst() == metadata.getSrc())
+                //    return;
+                client.doPush();
+                //pipe.onComplete();
+                client.completePush();
+            } else if (PipeHandleNotificationEvent.Type.PULL == type) {
+                client.pull(metadata, pipe);
+            } else {
+                client.unaryCall(pipeHandlerInfo.getPacket(), pipe);
+            }
+
+            return 0;
+        };
+
+        try {
+            result = retryer.call(pushStreamRetry);
+        } catch (ExecutionException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (RetryException e) {
+            LOGGER.error("Error getting ManagedChannel after retries");
         }
+
+
+
     }
 }

--- a/jvm/roll_site/main/scala/RollSiteUtil.scala
+++ b/jvm/roll_site/main/scala/RollSiteUtil.scala
@@ -46,9 +46,13 @@ class RollSiteUtil(val erSessionId: String,
     }
   })
 
-  def putBatch(value:ByteBuffer): Unit = {
+  def putBatch(value: ByteBuffer): Unit = {
+    putBatch(ByteString.copyFrom(value))
+  }
+
+  def putBatch(value: ByteString): Unit = {
     val broker = new LinkedBlockingBroker[ByteString]()
-    broker.put(ByteString.copyFrom(value))
+    broker.put(value)
     broker.signalWriteFinish()
     rp.putBatch(broker, options = options)
   }

--- a/jvm/roll_site/main/scala/RollSiteUtil.scala
+++ b/jvm/roll_site/main/scala/RollSiteUtil.scala
@@ -22,21 +22,21 @@ import java.nio.ByteBuffer
 import com.google.protobuf.ByteString
 import com.webank.eggroll.core.ErSession
 import com.webank.eggroll.core.datastructure.LinkedBlockingBroker
-import com.webank.eggroll.core.meta.ErFederationHeader
+import com.webank.eggroll.core.meta.ErRollSiteHeader
 import com.webank.eggroll.rollpair.{RollPair, RollPairContext}
 
 
 class RollSiteUtil(val erSessionId: String,
-                   federationHeader: ErFederationHeader,
+                   rollSiteHeader: ErRollSiteHeader,
                    options: Map[String, String] = Map.empty) {
   private val session =  new ErSession(sessionId = erSessionId, createIfNotExists = false)
   private val ctx = new RollPairContext(session)
   //private val nameStripped = name
-  val namespace = federationHeader.federationSessionId
-  val name = federationHeader.concat()
+  val namespace = rollSiteHeader.rollSiteSessionId
+  val name = rollSiteHeader.concat()
 
   println("scalaPutBatch  name:" + name + ",namespace:" + namespace)
-  val rp: RollPair = ctx.load(namespace, name, options = federationHeader.options)
+  val rp: RollPair = ctx.load(namespace, name, options = rollSiteHeader.options)
 
   Runtime.getRuntime.addShutdownHook(new Thread(){
     override def run(): Unit = {

--- a/jvm/roll_site/main/scala/RollSiteUtil.scala
+++ b/jvm/roll_site/main/scala/RollSiteUtil.scala
@@ -23,19 +23,21 @@ import com.google.protobuf.ByteString
 import com.webank.eggroll.core.ErSession
 import com.webank.eggroll.core.datastructure.LinkedBlockingBroker
 import com.webank.eggroll.core.meta.ErRollSiteHeader
+import com.webank.eggroll.core.util.Logging
 import com.webank.eggroll.rollpair.{RollPair, RollPairContext}
+import com.webank.eggroll.rollsite.infra.JobStatus
 
 
 class RollSiteUtil(val erSessionId: String,
                    rollSiteHeader: ErRollSiteHeader,
-                   options: Map[String, String] = Map.empty) {
+                   options: Map[String, String] = Map.empty) extends Logging {
   private val session =  new ErSession(sessionId = erSessionId, createIfNotExists = false)
   private val ctx = new RollPairContext(session)
   //private val nameStripped = name
   val namespace = rollSiteHeader.rollSiteSessionId
   val name = rollSiteHeader.concat()
 
-  println("scalaPutBatch  name:" + name + ",namespace:" + namespace)
+  logDebug("scalaPutBatch name:" + name + ",namespace:" + namespace)
   val rp: RollPair = ctx.load(namespace, name, options = rollSiteHeader.options)
 
   Runtime.getRuntime.addShutdownHook(new Thread(){
@@ -51,12 +53,20 @@ class RollSiteUtil(val erSessionId: String,
   }
 
   def putBatch(value: ByteString): Unit = {
-    if(value.size() == 0) {
-      throw new IllegalArgumentException("roll site push batch zero size:" + name)
+    JobStatus.increasePutBatchCount(name);
+    try {
+      if (value.size() == 0) {
+        throw new IllegalArgumentException("roll site push batch zero size:" + name)
+      }
+      val broker = new LinkedBlockingBroker[ByteString]()
+      broker.put(value)
+      broker.signalWriteFinish()
+      rp.putBatch(broker, options = options)
+
+      logInfo(s"put batch finished for name: ${name}, namespace: ${namespace}")
+    } finally {
+      JobStatus.decreasePutBatchCount(name);
     }
-    val broker = new LinkedBlockingBroker[ByteString]()
-    broker.put(value)
-    broker.signalWriteFinish()
-    rp.putBatch(broker, options = options)
   }
+
 }

--- a/jvm/roll_site/main/scala/RollSiteUtil.scala
+++ b/jvm/roll_site/main/scala/RollSiteUtil.scala
@@ -51,6 +51,9 @@ class RollSiteUtil(val erSessionId: String,
   }
 
   def putBatch(value: ByteString): Unit = {
+    if(value.size() == 0) {
+      throw new IllegalArgumentException("roll site push batch zero size:" + name)
+    }
     val broker = new LinkedBlockingBroker[ByteString]()
     broker.put(value)
     broker.signalWriteFinish()

--- a/proto/core/transfer.proto
+++ b/proto/core/transfer.proto
@@ -33,8 +33,8 @@ message TransferBatch {
   bytes data = 3;
 }
 
-message FederationHeader {
-  string federationSessionId = 1;
+message RollSiteHeader {
+  string rollSiteSessionId = 1;
   string name = 2;
   string tag = 3;
   string srcRole = 4;

--- a/python/arch/api/table/eggroll2/table_impl.py
+++ b/python/arch/api/table/eggroll2/table_impl.py
@@ -17,8 +17,9 @@
 import uuid
 from typing import Iterable
 
-from arch.api.table.table import Table
 from arch.api.utils.profile_util import log_elapsed
+
+from arch.api.table.table import Table
 
 
 # noinspection SpellCheckingInspection,PyProtectedMember,PyPep8Naming
@@ -140,7 +141,7 @@ class DTable(Table):
 
     @log_elapsed
     def reduce(self, func, **kwargs):
-        return (self._dtable.reduce(func).first()[1])
+        return self._dtable.reduce(func)
 
     @log_elapsed
     def join(self, other, func, **kwargs):

--- a/python/arch/api/transfer/roll_site_bridge.py
+++ b/python/arch/api/transfer/roll_site_bridge.py
@@ -42,7 +42,7 @@ def init_roll_site_context(runtime_conf, session_id):
                'proxy_endpoint': ErEndpoint(host, int(port))
               }
 
-    rs_context = RollSiteContext(session_id, options=options, rp_ctx=rp_context)
+    rs_context = RollSiteContext(session_id, rp_ctx=rp_context, options=options)
     LOGGER.info("init_roll_site_context done: {}".format(rs_context.__dict__))
     return rp_context, rs_context
 

--- a/python/arch/api/transfer/roll_site_bridge.py
+++ b/python/arch/api/transfer/roll_site_bridge.py
@@ -74,7 +74,7 @@ class FederationRuntime(Federation):
         futures = rs.pull(parties=rs_parties)
         for future in futures:
             obj = future.result()
-            LOGGER.info("federation got: {}".format(obj))
+            LOGGER.info(f'federation got data. tag: {tag}')
             if isinstance(obj, RollPair):
                 rtn.append(DTable.from_dtable(obj.ctx.get_session().get_session_id(),obj))
                 rubbish.add_table(obj)

--- a/python/eggroll/core/client.py
+++ b/python/eggroll/core/client.py
@@ -73,7 +73,7 @@ class CommandClient(object):
             else:
                 return []
         except Exception as e:
-            L.exception(f'Error calling to {endpoint}, command_uri: {command_uri}, req:{request}')
+            L.error(f'Error calling to {endpoint}, command_uri: {command_uri}, req:{request}')
             raise CommandCallError(command_uri, endpoint, e)
 
     def async_call(self, args, output_types: list, command_uri: CommandURI, serdes_type=SerdesTypes.PROTOBUF, parallel_size=5):
@@ -224,7 +224,9 @@ class ClusterManagerClient(object):
 
 
 class NodeManagerClient(object):
-    def __init__(self, options={NodeManagerConfKeys.CONFKEY_NODE_MANAGER_HOST: 'localhost', NodeManagerConfKeys.CONFKEY_NODE_MANAGER_PORT: 9394}):
+    def __init__(self, options: dict = None):
+        if options is None:
+            options = {}
         self.__endpoint = ErEndpoint(options[NodeManagerConfKeys.CONFKEY_NODE_MANAGER_HOST], int(options[NodeManagerConfKeys.CONFKEY_NODE_MANAGER_PORT]))
         if 'serdes_type' in options:
             self.__serdes_type = options['serdes_type']

--- a/python/eggroll/core/pair_store/roll_site_adapter.py
+++ b/python/eggroll/core/pair_store/roll_site_adapter.py
@@ -25,7 +25,7 @@ from eggroll.core.pair_store.format import PairBinWriter, ArrayByteBuffer
 from eggroll.core.proto import meta_pb2
 from eggroll.core.proto import proxy_pb2, proxy_pb2_grpc
 from eggroll.core.serdes import eggroll_serdes
-from eggroll.core.transfer_model import ErFederationHeader
+from eggroll.core.transfer_model import ErRollSiteHeader
 from eggroll.core.utils import stringify_charset
 from eggroll.roll_site.utils.roll_site_utils import create_store_name
 from eggroll.utils.log_utils import get_logger
@@ -41,7 +41,7 @@ class RollSiteAdapter(PairAdapter):
 
         self.namespace = options["path"].split("/")[-3]
         self.federation_header_string = options['federation_header']
-        self.federation_header = ErFederationHeader.from_proto_string(self.federation_header_string.encode(stringify_charset))
+        self.federation_header = ErRollSiteHeader.from_proto_string(self.federation_header_string.encode(stringify_charset))
         self.proxy_endpoint = ErEndpoint.from_proto_string(options['proxy_endpoint'].encode(stringify_charset))
 
         name = options["path"].split("/")[-2]
@@ -102,7 +102,7 @@ class RollSiteWriteBatch(PairWriteBatch):
             options = {}
         self.adapter = adapter
 
-        self.federation_header: ErFederationHeader = adapter.federation_header
+        self.federation_header: ErRollSiteHeader = adapter.federation_header
         self.namespace = adapter.namespace
         self.name = create_store_name(self.federation_header)
 

--- a/python/eggroll/core/pair_store/roll_site_adapter.py
+++ b/python/eggroll/core/pair_store/roll_site_adapter.py
@@ -100,7 +100,7 @@ class RollSiteWriteBatch(PairWriteBatch):
         channel = self.grpc_channel_factory.create_channel(self.proxy_endpoint)
         self.stub = proxy_pb2_grpc.DataTransferServiceStub(channel)
 
-        self.__bin_packet_len = 1 << 20
+        self.__bin_packet_len = 32 << 20
         self.total_written = 0
 
         self.ba = bytearray(self.__bin_packet_len)
@@ -164,7 +164,7 @@ class RollSiteWriteBatch(PairWriteBatch):
                 time.sleep(min(0.1 * i, 30))
 
         if exception:
-            raise GrpcCallError("error in push", self.proxy_endpoint, e)
+            raise GrpcCallError("error in push", self.proxy_endpoint, exception)
 
     def write(self):
         bin_data = bytes(self.ba[0:self.buffer.get_offset()])

--- a/python/eggroll/core/proto/transfer_pb2.py
+++ b/python/eggroll/core/proto/transfer_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='com.webank.eggroll.core.transfer',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x0etransfer.proto\x12 com.webank.eggroll.core.transfer\"L\n\x0eTransferHeader\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0b\n\x03tag\x18\x02 \x01(\t\x12\x11\n\ttotalSize\x18\x03 \x01(\x03\x12\x0e\n\x06status\x18\x04 \x01(\t\"r\n\rTransferBatch\x12@\n\x06header\x18\x01 \x01(\x0b\x32\x30.com.webank.eggroll.core.transfer.TransferHeader\x12\x11\n\tbatchSize\x18\x02 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\xa8\x02\n\x10\x46\x65\x64\x65rationHeader\x12\x1b\n\x13\x66\x65\x64\x65rationSessionId\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0b\n\x03tag\x18\x03 \x01(\t\x12\x0f\n\x07srcRole\x18\x04 \x01(\t\x12\x12\n\nsrcPartyId\x18\x05 \x01(\t\x12\x0f\n\x07\x64stRole\x18\x06 \x01(\t\x12\x12\n\ndstPartyId\x18\x07 \x01(\t\x12\x10\n\x08\x64\x61taType\x18\x08 \x01(\t\x12P\n\x07options\x18\n \x03(\x0b\x32?.com.webank.eggroll.core.transfer.FederationHeader.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\xdb\x02\n\x0fTransferService\x12j\n\x04send\x12/.com.webank.eggroll.core.transfer.TransferBatch\x1a/.com.webank.eggroll.core.transfer.TransferBatch(\x01\x12j\n\x04recv\x12/.com.webank.eggroll.core.transfer.TransferBatch\x1a/.com.webank.eggroll.core.transfer.TransferBatch0\x01\x12p\n\x08sendRecv\x12/.com.webank.eggroll.core.transfer.TransferBatch\x1a/.com.webank.eggroll.core.transfer.TransferBatch(\x01\x30\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x0etransfer.proto\x12 com.webank.eggroll.core.transfer\"L\n\x0eTransferHeader\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0b\n\x03tag\x18\x02 \x01(\t\x12\x11\n\ttotalSize\x18\x03 \x01(\x03\x12\x0e\n\x06status\x18\x04 \x01(\t\"r\n\rTransferBatch\x12@\n\x06header\x18\x01 \x01(\x0b\x32\x30.com.webank.eggroll.core.transfer.TransferHeader\x12\x11\n\tbatchSize\x18\x02 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\xa2\x02\n\x0eRollSiteHeader\x12\x19\n\x11rollSiteSessionId\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0b\n\x03tag\x18\x03 \x01(\t\x12\x0f\n\x07srcRole\x18\x04 \x01(\t\x12\x12\n\nsrcPartyId\x18\x05 \x01(\t\x12\x0f\n\x07\x64stRole\x18\x06 \x01(\t\x12\x12\n\ndstPartyId\x18\x07 \x01(\t\x12\x10\n\x08\x64\x61taType\x18\x08 \x01(\t\x12N\n\x07options\x18\n \x03(\x0b\x32=.com.webank.eggroll.core.transfer.RollSiteHeader.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\xdb\x02\n\x0fTransferService\x12j\n\x04send\x12/.com.webank.eggroll.core.transfer.TransferBatch\x1a/.com.webank.eggroll.core.transfer.TransferBatch(\x01\x12j\n\x04recv\x12/.com.webank.eggroll.core.transfer.TransferBatch\x1a/.com.webank.eggroll.core.transfer.TransferBatch0\x01\x12p\n\x08sendRecv\x12/.com.webank.eggroll.core.transfer.TransferBatch\x1a/.com.webank.eggroll.core.transfer.TransferBatch(\x01\x30\x01\x62\x06proto3')
 )
 
 
@@ -122,22 +122,22 @@ _TRANSFERBATCH = _descriptor.Descriptor(
 )
 
 
-_FEDERATIONHEADER_OPTIONSENTRY = _descriptor.Descriptor(
+_ROLLSITEHEADER_OPTIONSENTRY = _descriptor.Descriptor(
   name='OptionsEntry',
-  full_name='com.webank.eggroll.core.transfer.FederationHeader.OptionsEntry',
+  full_name='com.webank.eggroll.core.transfer.RollSiteHeader.OptionsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='com.webank.eggroll.core.transfer.FederationHeader.OptionsEntry.key', index=0,
+      name='key', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.OptionsEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='com.webank.eggroll.core.transfer.FederationHeader.OptionsEntry.value', index=1,
+      name='value', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.OptionsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -155,75 +155,75 @@ _FEDERATIONHEADER_OPTIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=497,
-  serialized_end=543,
+  serialized_start=491,
+  serialized_end=537,
 )
 
-_FEDERATIONHEADER = _descriptor.Descriptor(
-  name='FederationHeader',
-  full_name='com.webank.eggroll.core.transfer.FederationHeader',
+_ROLLSITEHEADER = _descriptor.Descriptor(
+  name='RollSiteHeader',
+  full_name='com.webank.eggroll.core.transfer.RollSiteHeader',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='federationSessionId', full_name='com.webank.eggroll.core.transfer.FederationHeader.federationSessionId', index=0,
+      name='rollSiteSessionId', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.rollSiteSessionId', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='name', full_name='com.webank.eggroll.core.transfer.FederationHeader.name', index=1,
+      name='name', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='tag', full_name='com.webank.eggroll.core.transfer.FederationHeader.tag', index=2,
+      name='tag', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.tag', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='srcRole', full_name='com.webank.eggroll.core.transfer.FederationHeader.srcRole', index=3,
+      name='srcRole', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.srcRole', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='srcPartyId', full_name='com.webank.eggroll.core.transfer.FederationHeader.srcPartyId', index=4,
+      name='srcPartyId', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.srcPartyId', index=4,
       number=5, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='dstRole', full_name='com.webank.eggroll.core.transfer.FederationHeader.dstRole', index=5,
+      name='dstRole', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.dstRole', index=5,
       number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='dstPartyId', full_name='com.webank.eggroll.core.transfer.FederationHeader.dstPartyId', index=6,
+      name='dstPartyId', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.dstPartyId', index=6,
       number=7, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='dataType', full_name='com.webank.eggroll.core.transfer.FederationHeader.dataType', index=7,
+      name='dataType', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.dataType', index=7,
       number=8, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='options', full_name='com.webank.eggroll.core.transfer.FederationHeader.options', index=8,
+      name='options', full_name='com.webank.eggroll.core.transfer.RollSiteHeader.options', index=8,
       number=10, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -232,7 +232,7 @@ _FEDERATIONHEADER = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_FEDERATIONHEADER_OPTIONSENTRY, ],
+  nested_types=[_ROLLSITEHEADER_OPTIONSENTRY, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -242,15 +242,15 @@ _FEDERATIONHEADER = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=247,
-  serialized_end=543,
+  serialized_end=537,
 )
 
 _TRANSFERBATCH.fields_by_name['header'].message_type = _TRANSFERHEADER
-_FEDERATIONHEADER_OPTIONSENTRY.containing_type = _FEDERATIONHEADER
-_FEDERATIONHEADER.fields_by_name['options'].message_type = _FEDERATIONHEADER_OPTIONSENTRY
+_ROLLSITEHEADER_OPTIONSENTRY.containing_type = _ROLLSITEHEADER
+_ROLLSITEHEADER.fields_by_name['options'].message_type = _ROLLSITEHEADER_OPTIONSENTRY
 DESCRIPTOR.message_types_by_name['TransferHeader'] = _TRANSFERHEADER
 DESCRIPTOR.message_types_by_name['TransferBatch'] = _TRANSFERBATCH
-DESCRIPTOR.message_types_by_name['FederationHeader'] = _FEDERATIONHEADER
+DESCRIPTOR.message_types_by_name['RollSiteHeader'] = _ROLLSITEHEADER
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 TransferHeader = _reflection.GeneratedProtocolMessageType('TransferHeader', (_message.Message,), dict(
@@ -267,23 +267,23 @@ TransferBatch = _reflection.GeneratedProtocolMessageType('TransferBatch', (_mess
   ))
 _sym_db.RegisterMessage(TransferBatch)
 
-FederationHeader = _reflection.GeneratedProtocolMessageType('FederationHeader', (_message.Message,), dict(
+RollSiteHeader = _reflection.GeneratedProtocolMessageType('RollSiteHeader', (_message.Message,), dict(
 
   OptionsEntry = _reflection.GeneratedProtocolMessageType('OptionsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _FEDERATIONHEADER_OPTIONSENTRY,
+    DESCRIPTOR = _ROLLSITEHEADER_OPTIONSENTRY,
     __module__ = 'transfer_pb2'
-    # @@protoc_insertion_point(class_scope:com.webank.eggroll.core.transfer.FederationHeader.OptionsEntry)
+    # @@protoc_insertion_point(class_scope:com.webank.eggroll.core.transfer.RollSiteHeader.OptionsEntry)
     ))
   ,
-  DESCRIPTOR = _FEDERATIONHEADER,
+  DESCRIPTOR = _ROLLSITEHEADER,
   __module__ = 'transfer_pb2'
-  # @@protoc_insertion_point(class_scope:com.webank.eggroll.core.transfer.FederationHeader)
+  # @@protoc_insertion_point(class_scope:com.webank.eggroll.core.transfer.RollSiteHeader)
   ))
-_sym_db.RegisterMessage(FederationHeader)
-_sym_db.RegisterMessage(FederationHeader.OptionsEntry)
+_sym_db.RegisterMessage(RollSiteHeader)
+_sym_db.RegisterMessage(RollSiteHeader.OptionsEntry)
 
 
-_FEDERATIONHEADER_OPTIONSENTRY._options = None
+_ROLLSITEHEADER_OPTIONSENTRY._options = None
 
 _TRANSFERSERVICE = _descriptor.ServiceDescriptor(
   name='TransferService',
@@ -291,8 +291,8 @@ _TRANSFERSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=546,
-  serialized_end=893,
+  serialized_start=540,
+  serialized_end=887,
   methods=[
   _descriptor.MethodDescriptor(
     name='send',

--- a/python/eggroll/core/session.py
+++ b/python/eggroll/core/session.py
@@ -59,6 +59,7 @@ class ErSession(object):
         static_er_conf = get_static_er_conf()
         if not static_er_conf:
             conf_path = options.get(CoreConfKeys.STATIC_CONF_PATH, f"{self.__eggroll_home}/conf/eggroll.properties")
+            L.info(f"static conf path: {conf_path}")
             configs = configparser.ConfigParser()
             configs.read(conf_path)
             set_static_er_conf(configs['eggroll'])

--- a/python/eggroll/core/transfer/transfer_service.py
+++ b/python/eggroll/core/transfer/transfer_service.py
@@ -185,8 +185,8 @@ class GrpcTransferService(TransferService):
 class TransferClient(object):
     def __init__(self):
         self.__grpc_channel_factory = GrpcChannelFactory()
-        self.__bin_packet_len = 1 << 20
-        self.__chunk_size = 100
+        #self.__bin_packet_len = 32 << 20
+        #self.__chunk_size = 100
 
     @_exception_logger
     def send(self, broker, endpoint: ErEndpoint, tag):

--- a/python/eggroll/core/transfer/transfer_service.py
+++ b/python/eggroll/core/transfer/transfer_service.py
@@ -66,7 +66,7 @@ class TransferService(object):
         result = TransferService.data_buffer.get(key, None)
         retry = 0
         while not result or key not in TransferService.data_buffer:
-            sleep(0.1)
+            sleep(min(0.1 * retry, 30))
             L.debug(f"waiting broker tag:{key}, retry:{retry}")
             result = TransferService.data_buffer.get(key, None)
             retry += 1
@@ -133,10 +133,11 @@ class GrpcTransferServicer(transfer_pb2_grpc.TransferServiceServicer):
             L.info(f'GrpcTransferServicer stream finished. tag: {base_tag}, remaining write count: {broker,broker.__dict__}, stream not empty')
             result = transfer_pb2.TransferBatch(header=response_header)
         else:
-            L.debug(f'broker is None. Getting tag from metadata')
+            L.warn(f'broker is None. Getting tag from metadata')
             metadata = dict(context.invocation_metadata())
-            broker = TransferService.get_broker(metadata[TRANSFER_BROKER_NAME])
-            L.debug("empty requests")
+            base_tag = metadata[TRANSFER_BROKER_NAME]
+            broker = TransferService.get_broker(base_tag)
+            L.debug(f"empty requests: {base_tag}")
             L.info(f'GrpcTransferServicer stream finished. tag: {base_tag}, remaining write count: {broker,broker.__dict__}, stream empty')
             result = transfer_pb2.TransferBatch()
 

--- a/python/eggroll/core/transfer_model.py
+++ b/python/eggroll/core/transfer_model.py
@@ -91,9 +91,9 @@ class ErTransferBatch(RpcMessage):
                f'at {hex(id(self))}>'
 
 
-class ErFederationHeader(RpcMessage):
+class ErRollSiteHeader(RpcMessage):
     def __init__(self,
-            federation_session_id: str,
+            roll_site_session_id: str,
             name: str,
             tag: str,
             src_role: str,
@@ -102,7 +102,7 @@ class ErFederationHeader(RpcMessage):
             dst_party_id: str,
             data_type: str = '',
             options: dict = {}):
-        self._federation_session_id = federation_session_id
+        self._roll_site_session_id = roll_site_session_id
         self._name = name
         self._tag = tag
         self._src_role = src_role
@@ -113,8 +113,8 @@ class ErFederationHeader(RpcMessage):
         self._options = options.copy()
 
     def to_proto(self):
-        return transfer_pb2.FederationHeader(
-                federationSessionId=self._federation_session_id,
+        return transfer_pb2.RollSiteHeader(
+                rollSiteSessionId=self._roll_site_session_id,
                 name=self._name,
                 tag=self._tag,
                 srcRole=self._src_role,
@@ -129,25 +129,26 @@ class ErFederationHeader(RpcMessage):
 
     @staticmethod
     def from_proto(pb_message):
-        return ErFederationHeader(federation_session_id=pb_message.federationSessionId,
-                                  name=pb_message.name,
-                                  tag=pb_message.tag,
-                                  src_role=pb_message.srcRole,
-                                  src_party_id=pb_message.srcPartyId,
-                                  dst_role=pb_message.dstRole,
-                                  dst_party_id=pb_message.dstPartyId,
-                                  data_type=pb_message.dataType,
-                                  options=dict(pb_message.options))
+        return ErRollSiteHeader(
+            roll_site_session_id=pb_message.rollSiteSessionId,
+            name=pb_message.name,
+            tag=pb_message.tag,
+            src_role=pb_message.srcRole,
+            src_party_id=pb_message.srcPartyId,
+            dst_role=pb_message.dstRole,
+            dst_party_id=pb_message.dstPartyId,
+            data_type=pb_message.dataType,
+            options=dict(pb_message.options))
 
     @staticmethod
     def from_proto_string(pb_string):
-        pb_message = transfer_pb2.FederationHeader()
+        pb_message = transfer_pb2.RollSiteHeader()
         msg_len = pb_message.ParseFromString(pb_string)
-        return ErFederationHeader.from_proto(pb_message)
+        return ErRollSiteHeader.from_proto(pb_message)
 
     def __repr__(self):
-        return f'<ErFederationHeader(' \
-               f'federation_session_id={repr(self._federation_session_id)}), ' \
+        return f'<ErRollSiteHeader(' \
+               f'roll_site_session_id={repr(self._roll_site_session_id)}), ' \
                f'name={repr(self._name)}, ' \
                f'tag={repr(self._tag)}, ' \
                f'src_role={repr(self._src_role)}, ' \

--- a/python/eggroll/core/utils.py
+++ b/python/eggroll/core/utils.py
@@ -12,13 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
-import sys
 import time
 import traceback
 import uuid
-import numpy as np
 from datetime import datetime
 
+import numpy as np
 from google.protobuf.text_format import MessageToString
 
 static_er_conf = {}
@@ -179,5 +178,7 @@ def hash_code(s):
     return abs(h)
 
 
-def to_one_line_string(proto_msg, as_one_line=True):
-    return MessageToString(proto_msg, as_one_line=as_one_line)
+def to_one_line_string(msg, as_one_line=True):
+    if isinstance(msg, str) or isinstance(msg, bytes):
+        return msg
+    return MessageToString(msg, as_one_line=as_one_line)

--- a/python/eggroll/roll_pair/__init__.py
+++ b/python/eggroll/roll_pair/__init__.py
@@ -7,7 +7,7 @@ from eggroll.core.serdes.eggroll_serdes import PickleSerdes, \
 from eggroll.roll_pair.utils.pair_utils import get_db_path
 
 
-def create_adapter(er_partition: ErPartition, options=None):
+def create_adapter(er_partition: ErPartition, options: dict = None):
     if options is None:
         options = {}
     options['store_type'] = er_partition._store_locator._store_type

--- a/python/eggroll/roll_pair/egg_pair.py
+++ b/python/eggroll/roll_pair/egg_pair.py
@@ -364,7 +364,7 @@ class EggPair(object):
             if 0 == partition_id:
                 partition_size = input_partition._store_locator._total_partitions
                 queue = TransferService.get_or_create_broker(transfer_tag, write_signals=partition_size - 1)
-                if not first:
+                if not first or not is_reduce:
                     comb_op_result = seq_op_result
                 else:
                     comb_op_result = zero_value

--- a/python/eggroll/roll_pair/egg_pair.py
+++ b/python/eggroll/roll_pair/egg_pair.py
@@ -132,7 +132,6 @@ class EggPair(object):
             tag = f'{task._id}'
             def generate_broker():
                 with create_adapter(task._inputs[0]) as db, db.iteritems() as rb:
-                    print("create_adapter")
                     yield from TransferPair.pair_to_bin_batch(rb)
                     # TODO:0 how to remove?
                     # TransferService.remove_broker(tag)
@@ -410,7 +409,7 @@ def serve(args):
             route_to_class_name="EggPair",
             route_to_method_name="run_task")
 
-    command_server = grpc.server(futures.ThreadPoolExecutor(max_workers=500, thread_name_prefix="command_server"),
+    command_server = grpc.server(futures.ThreadPoolExecutor(max_workers=500, thread_name_prefix="grpc_server"),
                                  options=[
                                      ("grpc.max_metadata_size", 32 << 20),
                                      (cygrpc.ChannelArgKey.max_send_message_length, 2 << 30 - 1),

--- a/python/eggroll/roll_pair/roll_pair.py
+++ b/python/eggroll/roll_pair/roll_pair.py
@@ -251,6 +251,7 @@ class RollPair(object):
     UNION = 'union'
 
     def __setstate__(self, state):
+        self.gc_enable = None
         pass
 
     def __getstate__(self):

--- a/python/eggroll/roll_pair/roll_pair.py
+++ b/python/eggroll/roll_pair/roll_pair.py
@@ -430,7 +430,7 @@ class RollPair(object):
         transfer_pair = TransferPair(transfer_id=job_id)
         done_cnt = 0
         for k, v in transfer_pair.gather(populated_store):
-            done_cnt +=1
+            done_cnt += 1
             yield self.key_serdes.deserialize(k), self.value_serdes.deserialize(v)
         L.debug(f"get_all count:{done_cnt}")
 
@@ -762,7 +762,7 @@ class RollPair(object):
 
         er_store = job_result._outputs[0]
 
-        return RollPair(er_store, self.ctx)
+        return RollPair(er_store, self.ctx).get('result')
 
     def aggregate(self, zero_value, seq_op, comb_op, output=None, options: dict = None):
         if options is None:
@@ -789,7 +789,7 @@ class RollPair(object):
 
         er_store = job_result._outputs[0]
 
-        return RollPair(er_store, self.ctx)
+        return RollPair(er_store, self.ctx).get('result')
 
     def glom(self, output=None, options: dict = None):
         if options is None:

--- a/python/eggroll/roll_pair/roll_pair.py
+++ b/python/eggroll/roll_pair/roll_pair.py
@@ -12,9 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import os
 import sys
-import threading
 import uuid
 from concurrent.futures import wait, FIRST_EXCEPTION
 from threading import Thread
@@ -281,14 +279,12 @@ class RollPair(object):
             self.ctx.gc_recorder.delete_record(self.__store)
             L.debug(f'del rp: {self}')
             self.destroy()
-            L.debug("process {} thread {} run {} del table name:{}, namespace:{}".
-                         format(os.getpid(), threading.currentThread().ident,
-                                sys._getframe().f_code.co_name,
-                                self.__store._store_locator._name,
-                                self.__store._store_locator._namespace))
+            L.debug(f"running gc: {sys._getframe().f_code.co_name}. "
+                    f"deleting store name: {self.__store._store_locator._name}, "
+                    f"namespace: {self.__store._store_locator._namespace}")
 
     def __repr__(self):
-        return f'python RollPair(_store={self.__store})'
+        return f'<RollPair(_store={self.__store}) at {hex(id(self))}>'
 
     def enable_gc(self):
         self.gc_enable = True

--- a/python/eggroll/roll_pair/roll_pair.py
+++ b/python/eggroll/roll_pair/roll_pair.py
@@ -344,7 +344,7 @@ class RollPair(object):
         partition_id = self.partitioner(k)
         egg = self.ctx.route_to_egg(self.__store._partitions[partition_id])
         L.info(egg._command_endpoint)
-        L.info(f"count:{self.__store._store_locator._total_partitions}")
+        L.info(f"partitions count: {self.__store._store_locator._total_partitions}")
         inputs = [ErPartition(id=partition_id, store_locator=self.__store._store_locator)]
         output = [ErPartition(id=partition_id, store_locator=self.__store._store_locator)]
 
@@ -482,7 +482,7 @@ class RollPair(object):
             bb.signal_write_finish()
 
         scatter_results = scatter_future.result()
-        L.debug(f"scatter_results:{scatter_results}")
+        L.debug(f"scatter_results: {scatter_results}")
         th.join()
         return RollPair(populated_store, self.ctx)
 

--- a/python/eggroll/roll_pair/test/test_roll_pair.py
+++ b/python/eggroll/roll_pair/test/test_roll_pair.py
@@ -325,6 +325,16 @@ class TestRollPairMultiPartition(TestRollPairBase):
         self.assertEqual(st_opts["total_partitions"], rp.get_partitions())
         rp.destroy()
 
+    def test_count(self):
+        super().test_count()
+
+    def test_aggregate_parallelize(self):
+        from operator import mul, add
+        data1 = self.ctx.parallelize([(i, i) for i in range(1, 5)], options={"total_partitions": 1})
+        h2 = data1.aggregate(zero_value=1, seq_op=mul, comb_op=add)
+
+        self.assertEqual(h2.get(b'result'), 24)
+
 
 class TestRollPairStandalone(TestRollPairBase):
     ctx = None

--- a/python/eggroll/roll_pair/transfer_pair.py
+++ b/python/eggroll/roll_pair/transfer_pair.py
@@ -152,7 +152,7 @@ class TransferPair(object):
         writer = None
 
         def commit(bs=buffer_size):
-            L.debug(f'generate_bin_batch commit:{done_cnt}')
+            L.debug(f'generate_bin_batch commit: {done_cnt}')
             nonlocal ba
             nonlocal buffer
             nonlocal writer

--- a/python/eggroll/roll_site/roll_site.py
+++ b/python/eggroll/roll_site/roll_site.py
@@ -24,7 +24,7 @@ from eggroll.core.grpc.factory import GrpcChannelFactory
 from eggroll.core.meta_model import ErStoreLocator, ErStore
 from eggroll.core.proto import proxy_pb2, proxy_pb2_grpc
 from eggroll.core.serdes import eggroll_serdes
-from eggroll.core.transfer_model import ErFederationHeader
+from eggroll.core.transfer_model import ErRollSiteHeader
 from eggroll.core.utils import _stringify
 from eggroll.roll_pair.roll_pair import RollPair, RollPairContext
 from eggroll.roll_site.utils.roll_site_utils import create_store_name, DELIM
@@ -139,7 +139,7 @@ class RollSite:
             return
         self.ctx.push_count -= 1
 
-    def _thread_receive(self, packet, namespace, federation_header: ErFederationHeader):
+    def _thread_receive(self, packet, namespace, federation_header: ErRollSiteHeader):
         try:
             table_name = create_store_name(federation_header)
             is_standalone = self.ctx.rp_ctx.get_session().get_option(SessionConfKeys.CONFKEY_SESSION_DEPLOY_MODE) \
@@ -202,15 +202,16 @@ class RollSite:
 
             _options = {}
             obj_type = 'rollpair' if isinstance(obj, RollPair) else 'object'
-            federation_header = ErFederationHeader(federation_session_id=self.federation_session_id,
-                                                   name=self.name,
-                                                   tag=self.tag,
-                                                   src_role=self.local_role,
-                                                   src_party_id=self.party_id,
-                                                   dst_role=_role,
-                                                   dst_party_id=_party_id,
-                                                   data_type=obj_type,
-                                                   options=_options)
+            federation_header = ErRollSiteHeader(
+                roll_site_session_id=self.federation_session_id,
+                name=self.name,
+                tag=self.tag,
+                src_role=self.local_role,
+                src_party_id=self.party_id,
+                dst_role=_role,
+                dst_party_id=_party_id,
+                data_type=obj_type,
+                options=_options)
             _tagged_key = create_store_name(federation_header)
             L.debug(f"pushing start party:{type(obj)}, {_tagged_key}")
             namespace = self.federation_session_id
@@ -287,13 +288,14 @@ class RollSite:
         futures = []
         for src_role, src_party_id in parties:
             src_party_id = str(src_party_id)
-            federation_header = ErFederationHeader(federation_session_id=self.federation_session_id,
-                                                   name=self.name,
-                                                   tag=self.tag,
-                                                   src_role=src_role,
-                                                   src_party_id=src_party_id,
-                                                   dst_role=self.local_role,
-                                                   dst_party_id=self.party_id)
+            federation_header = ErRollSiteHeader(
+                roll_site_session_id=self.federation_session_id,
+                name=self.name,
+                tag=self.tag,
+                src_role=src_role,
+                src_party_id=src_party_id,
+                dst_role=self.local_role,
+                dst_party_id=self.party_id)
             _tagged_key = create_store_name(federation_header)
 
             name = _tagged_key

--- a/python/eggroll/roll_site/roll_site.py
+++ b/python/eggroll/roll_site/roll_site.py
@@ -57,25 +57,28 @@ class RollSiteContext:
             self.stub = proxy_pb2_grpc.DataTransferServiceStub(channel)
             self.init_job_session_pair(self.roll_site_session_id, self.rp_ctx.session_id)
 
-        self.push_count = 0
+        self.pushing_task_count = 0
         self.rp_ctx.get_session().add_exit_task(self.push_complete)
         L.info(f"inited RollSiteContext: {self.__dict__}")
 
     def push_complete(self):
-        L.debug("run roll site exit func:{}".format(self.push_count))
+        session_id = self.rp_ctx.get_session().get_session_id()
+        L.info(f"running roll site exit func for session: {session_id}")
         try_count = 0
+        max_try_count = 800
         while True:
-            if try_count >= 500:
-                L.error("try times reach 500, exiting")
+            if try_count >= max_try_count:
+                L.warn(f"try times reach {max_try_count} for session: {session_id}, exiting")
                 return
-            if self.push_count:
-                if try_count % 10 == 0:
-                    L.debug("session:{} waiting for push complete"
-                            .format(self.rp_ctx.get_session().get_session_id()))
+            if self.pushing_task_count:
+                L.info(f"session: {session_id} "
+                       f"waiting for all push tasks complete. "
+                       f"current try_count: {try_count}, "
+                       f"current pushing task count: {self.pushing_task_count}")
                 try_count += 1
-                import time
-                time.sleep(0.1)
+                time.sleep(min(0.1 * try_count, 60))
             else:
+                L.info(f"session: {session_id} finishes all pushing tasks")
                 return
 
     # todo:1: add options?
@@ -85,9 +88,9 @@ class RollSiteContext:
         return RollSite(name, tag, self, options=options)
 
     # todo:1: try-except as decorator
-    def init_job_session_pair(self, federation_session_id, session_id):
+    def init_job_session_pair(self, roll_site_session_id, er_session_id):
         try:
-            task_info = proxy_pb2.Task(model=proxy_pb2.Model(name=federation_session_id, dataKey=bytes(session_id, encoding='utf8')))
+            task_info = proxy_pb2.Task(model=proxy_pb2.Model(name=roll_site_session_id, dataKey=bytes(er_session_id, encoding='utf8')))
             topic_src = proxy_pb2.Topic(name="init_job_session_pair", partyId=self.party_id,
                                         role=self.role, callback=None)
             topic_dst = proxy_pb2.Topic(name="init_job_session_pair", partyId=self.party_id,
@@ -128,7 +131,7 @@ class RollSite:
         self.party_id = self.ctx.party_id
         self.dst_host = self.ctx.proxy_endpoint._host
         self.dst_port = self.ctx.proxy_endpoint._port
-        self.federation_session_id = self.ctx.roll_site_session_id
+        self.roll_site_session_id = self.ctx.roll_site_session_id
         self.local_role = self.ctx.role
         self.name = name
         self.tag = tag
@@ -137,14 +140,14 @@ class RollSite:
         self.complete_pool = ThreadPoolExecutor(10, thread_name_prefix="complete-wait")
 
     def _decrease_push_count(self, fn):
-        if self.ctx.push_count <= 0:
-            self.ctx.push_count = 0
+        if self.ctx.pushing_task_count <= 0:
+            self.ctx.pushing_task_count = 0
             return
-        self.ctx.push_count -= 1
+        self.ctx.pushing_task_count -= 1
 
-    def _thread_receive(self, packet, namespace, federation_header: ErRollSiteHeader):
+    def _thread_receive(self, packet, namespace, roll_site_header: ErRollSiteHeader):
         try:
-            table_name = create_store_name(federation_header)
+            table_name = create_store_name(roll_site_header)
             is_standalone = self.ctx.rp_ctx.get_session().get_option(SessionConfKeys.CONFKEY_SESSION_DEPLOY_MODE) \
                             == "standalone"
             if is_standalone:
@@ -165,7 +168,7 @@ class RollSite:
                         table_name = ret_list[1]
                         obj_type = ret_list[0]
                         break
-                    time.sleep(min(0.1 * retry_cnt, 60))
+                    time.sleep(min(0.1 * retry_cnt, 30))
 
             else:
                 retry_cnt = 0
@@ -181,10 +184,10 @@ class RollSite:
                     if ret_packet.header.ack in ERROR_STATES:
                         raise IOError("receive terminated")
                     ret_packet = self.stub.unaryCall(packet)
-                    time.sleep(min(0.1*retry_cnt, 60))
+                    time.sleep(min(0.1 * retry_cnt, 30))
                 obj_type = ret_packet.body.value
 
-                table_namespace = self.federation_session_id
+                table_namespace = self.roll_site_session_id
             L.debug(f"pull status done: table_name:{table_name}, packet:{to_one_line_string(packet)}, namespace:{namespace}")
             rp = self.ctx.rp_ctx.load(namespace=table_namespace, name=table_name)
             result = rp.get(table_name) if obj_type == b'object' else rp
@@ -196,7 +199,7 @@ class RollSite:
 
     def push(self, obj, parties: list = None):
         L.info(f"pushing: self:{self.__dict__}, obj_type:{type(obj)}, parties:{parties}")
-        self.ctx.push_count += 1
+        self.ctx.pushing_task_count += 1
         futures = []
         for role_party_id in parties:
             # for _partyId in _partyIds:
@@ -205,8 +208,8 @@ class RollSite:
 
             _options = {}
             obj_type = 'rollpair' if isinstance(obj, RollPair) else 'object'
-            federation_header = ErRollSiteHeader(
-                roll_site_session_id=self.federation_session_id,
+            roll_site_header = ErRollSiteHeader(
+                roll_site_session_id=self.roll_site_session_id,
                 name=self.name,
                 tag=self.tag,
                 src_role=self.local_role,
@@ -215,9 +218,9 @@ class RollSite:
                 dst_party_id=_party_id,
                 data_type=obj_type,
                 options=_options)
-            _tagged_key = create_store_name(federation_header)
+            _tagged_key = create_store_name(roll_site_header)
             L.debug(f"pushing start party:{type(obj)}, {_tagged_key}")
-            namespace = self.federation_session_id
+            namespace = self.roll_site_session_id
 
             if isinstance(obj, RollPair):
                 rp = obj
@@ -241,7 +244,7 @@ class RollSite:
                                            obj_type])
                     store_type = StoreTypes.ROLLPAIR_ROLLSITE
                 if is_standalone:
-                    status_rp = self.ctx.rp_ctx.load(namespace, STATUS_TABLE_NAME + DELIM + self.federation_session_id, options=_options)
+                    status_rp = self.ctx.rp_ctx.load(namespace, STATUS_TABLE_NAME + DELIM + self.roll_site_session_id, options=_options)
                     status_rp.disable_gc()
                     if isinstance(obj, RollPair):
                         status_rp.put(_tagged_key, (obj_type.encode("utf-8"), rp.get_name(), rp.get_namespace()))
@@ -259,13 +262,13 @@ class RollSite:
 
                     # TODO:0: move options from job to store when database modification finished
 
-                    options = {"federation_header": federation_header,
+                    options = {"roll_site_header": roll_site_header,
                                "proxy_endpoint": self.ctx.proxy_endpoint,
                                "obj_type": obj_type}
 
                     if isinstance(obj, RollPair):
-                        federation_header._options['total_partitions'] = obj.get_store()._store_locator._total_partitions
-                        L.debug(f"pushing map_values :{dst_name}, {obj.count()}, tag_key:{_tagged_key}")
+                        roll_site_header._options['total_partitions'] = obj.get_store()._store_locator._total_partitions
+                        L.debug(f"pushing map_values: {dst_name}, count: {obj.count()}, tag_key:{_tagged_key}")
                     rp.map_values(lambda v: v,
                         output=ErStore(store_locator=new_store_locator),
                                   options=options)
@@ -291,19 +294,19 @@ class RollSite:
         futures = []
         for src_role, src_party_id in parties:
             src_party_id = str(src_party_id)
-            federation_header = ErRollSiteHeader(
-                roll_site_session_id=self.federation_session_id,
+            roll_site_header = ErRollSiteHeader(
+                roll_site_session_id=self.roll_site_session_id,
                 name=self.name,
                 tag=self.tag,
                 src_role=src_role,
                 src_party_id=src_party_id,
                 dst_role=self.local_role,
                 dst_party_id=self.party_id)
-            _tagged_key = create_store_name(federation_header)
+            _tagged_key = create_store_name(roll_site_header)
 
             name = _tagged_key
 
-            model = proxy_pb2.Model(name=_stringify(federation_header))
+            model = proxy_pb2.Model(name=_stringify(roll_site_header))
             task_info = proxy_pb2.Task(taskId=name, model=model)
             topic_src = proxy_pb2.Topic(name="get_status", partyId=src_party_id,
                                         role=src_role, callback=None)
@@ -324,9 +327,9 @@ class RollSite:
                                           ack=0)
 
             packet = proxy_pb2.Packet(header=metadata)
-            namespace = self.federation_session_id
+            namespace = self.roll_site_session_id
             L.info(f"pulling prepared tagged_key: {_tagged_key}, packet:{to_one_line_string(packet)}")
-            futures.append(self.process_pool.submit(RollSite._thread_receive, self, packet, namespace, federation_header))
+            futures.append(self.process_pool.submit(RollSite._thread_receive, self, packet, namespace, roll_site_header))
 
         self.process_pool.shutdown(wait=False)
         return futures

--- a/python/eggroll/roll_site/test/roll_site_test_asset.py
+++ b/python/eggroll/roll_site/test/roll_site_test_asset.py
@@ -79,6 +79,8 @@ ER_STORE1 = ErStore(
                                      name="name"))
 
 
+roll_site_session_id = f'atest'
+
 def get_debug_test_context(is_standalone=False,
         manager_port=4670,
         egg_port=20001,
@@ -92,7 +94,7 @@ def get_debug_test_context(is_standalone=False,
                                              transfer_port=transfer_port,
                                              session_id=session_id)
 
-    rs_context = RollSiteContext("atest", options=get_option(role, props_file),
+    rs_context = RollSiteContext(roll_site_session_id, options=get_option(role, props_file),
                                  rp_ctx=rp_context)
 
     return rs_context
@@ -100,7 +102,7 @@ def get_debug_test_context(is_standalone=False,
 
 def get_standalone_context(role, props_file=default_props_file):
     rp_context = rpta.get_standalone_context()
-    rs_context = RollSiteContext("atest", options=get_option(role, props_file),
+    rs_context = RollSiteContext(roll_site_session_id, options=get_option(role, props_file),
                                  rp_ctx=rp_context)
 
     return rs_context
@@ -110,7 +112,7 @@ def get_cluster_context(role, options: dict = None, props_file=default_props_fil
     if options is None:
         options = {}
     rp_context = rpta.get_cluster_context(options=options)
-    rs_context = RollSiteContext("atest", options=get_option(role, props_file),
+    rs_context = RollSiteContext(roll_site_session_id, options=get_option(role, props_file),
                                  rp_ctx=rp_context)
 
     return rs_context

--- a/python/eggroll/roll_site/test/roll_site_test_asset.py
+++ b/python/eggroll/roll_site/test/roll_site_test_asset.py
@@ -94,16 +94,16 @@ def get_debug_test_context(is_standalone=False,
                                              transfer_port=transfer_port,
                                              session_id=session_id)
 
-    rs_context = RollSiteContext(roll_site_session_id, options=get_option(role, props_file),
-                                 rp_ctx=rp_context)
+    rs_context = RollSiteContext(roll_site_session_id, rp_ctx=rp_context,
+                                 options=get_option(role, props_file))
 
     return rs_context
 
 
 def get_standalone_context(role, props_file=default_props_file):
     rp_context = rpta.get_standalone_context()
-    rs_context = RollSiteContext(roll_site_session_id, options=get_option(role, props_file),
-                                 rp_ctx=rp_context)
+    rs_context = RollSiteContext(roll_site_session_id, rp_ctx=rp_context,
+                                 options=get_option(role, props_file))
 
     return rs_context
 
@@ -112,8 +112,8 @@ def get_cluster_context(role, options: dict = None, props_file=default_props_fil
     if options is None:
         options = {}
     rp_context = rpta.get_cluster_context(options=options)
-    rs_context = RollSiteContext(roll_site_session_id, options=get_option(role, props_file),
-                                 rp_ctx=rp_context)
+    rs_context = RollSiteContext(roll_site_session_id, rp_ctx=rp_context,
+                                 options=get_option(role, props_file))
 
     return rs_context
 

--- a/python/eggroll/roll_site/test/test_roll_site.py
+++ b/python/eggroll/roll_site/test/test_roll_site.py
@@ -29,7 +29,7 @@ props_file_guest = default_props_file
 props_file_guest = default_props_file + '.guest'
 
 
-row_limit = 30000000
+row_limit = 3
 
 
 def data_generator(limit):
@@ -228,8 +228,8 @@ class TestRollSiteCluster(TestRollSiteBase):
     @classmethod
     def setUpClass(cls) -> None:
         opts = {"eggroll.session.max.processors.per.node": "3"}
-        cls.rs_context_host = get_cluster_context(role='host', options=opts, props_file=props_file_host)
         cls.rs_context_guest = get_cluster_context(role='guest', options=opts, props_file=props_file_guest)
+        cls.rs_context_host = get_cluster_context(role='host', options=opts, props_file=props_file_host)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/python/eggroll/roll_site/test/test_roll_site.py
+++ b/python/eggroll/roll_site/test/test_roll_site.py
@@ -132,7 +132,7 @@ class TestRollSiteBase(unittest.TestCase):
             if isinstance(obj, RollPair):
                 key = "key-1"
                 value = obj.get(key)
-                #self.assertEqual(value, "value-1", f"got wrong value. expected: 'value-1', actual: {value}")
+                self.assertEqual(value, "value-1", f"got wrong value. expected: 'value-1', actual: {value}")
                 print("obj:", obj, ", value:", value, ", count:", obj.count())
             else:
                 raise TypeError(f'require getting a RollPair but obj found: {obj}')
@@ -164,7 +164,8 @@ class TestRollSiteBase(unittest.TestCase):
                 key = "key-1"
                 value = obj.get(key)
                 #self.assertEqual(value, "value-1", f"got wrong value. expected: 'value-1', actual: {value}")
-                print("obj:", obj, ", value:", value, ", count:", obj.count())
+                self.assertEqual(value, "value-1", f"got wrong value. expected: 'value-1', actual: {value}")
+                self.assertEqual(obj.count(), row_limit, f"got wrong count value. expected: {row_limit}, actual: {obj.count()}")
             else:
                 raise TypeError(f'require getting a RollPair but obj found: {obj}')
 
@@ -196,7 +197,6 @@ class TestRollSiteBase(unittest.TestCase):
         rp = rp_context.load("namespace", self._rp_rs_name_big_mp, options=rp_options)
         rp.put_all(data_generator(9), options=rp_options)
         print(f"count: {rp.count()}")
-
 
 
 class TestRollSiteStandalone(TestRollSiteBase):

--- a/python/eggroll/roll_site/test/test_roll_site.py
+++ b/python/eggroll/roll_site/test/test_roll_site.py
@@ -29,7 +29,7 @@ props_file_guest = default_props_file
 props_file_guest = default_props_file + '.guest'
 
 
-row_limit = 100
+row_limit = 3
 
 
 def data_generator(limit):
@@ -51,7 +51,7 @@ class TestRollSiteBase(unittest.TestCase):
     _rp_rs_name_big = "roll_pair_name.table.big"
     _rp_rs_tag_big = "roll_pair_tag.big"
 
-    _rp_rs_name_big_mp = "roll_pair_name.table.big.mp.small"
+    _rp_rs_name_big_mp = "roll_pair_name.table.big.mp.0"
     _rp_rs_tag_big_mp = "roll_pair_tag.big.mp"
 
     @classmethod

--- a/python/eggroll/roll_site/test/test_roll_site.py
+++ b/python/eggroll/roll_site/test/test_roll_site.py
@@ -29,7 +29,7 @@ props_file_guest = default_props_file
 props_file_guest = default_props_file + '.guest'
 
 
-row_limit = 3
+row_limit = 30000000
 
 
 def data_generator(limit):
@@ -212,9 +212,15 @@ class TestRollSiteStandalone(TestRollSiteBase):
         super().test_get()
 
     def test_remote_rollpair(self):
-        super().test_remote_rollpair()
+            super().test_remote_rollpair()
 
     def test_get_rollpair(self):
+        super().test_get_rollpair()
+
+    def test_remote_rollpair_big_multi_partitions(self):
+        super().test_remote_rollpair()
+
+    def test_get_rollpair_big_multi_partitions(self):
         super().test_get_rollpair()
 
 

--- a/python/eggroll/roll_site/test/test_roll_site.py
+++ b/python/eggroll/roll_site/test/test_roll_site.py
@@ -29,7 +29,7 @@ props_file_guest = default_props_file
 props_file_guest = default_props_file + '.guest'
 
 
-row_limit = 3
+row_limit = 100
 
 
 def data_generator(limit):
@@ -51,7 +51,7 @@ class TestRollSiteBase(unittest.TestCase):
     _rp_rs_name_big = "roll_pair_name.table.big"
     _rp_rs_tag_big = "roll_pair_tag.big"
 
-    _rp_rs_name_big_mp = "roll_pair_name.table.big.mp"
+    _rp_rs_name_big_mp = "roll_pair_name.table.big.mp.small"
     _rp_rs_tag_big_mp = "roll_pair_tag.big.mp"
 
     @classmethod

--- a/python/eggroll/roll_site/test/test_rollsite.py
+++ b/python/eggroll/roll_site/test/test_rollsite.py
@@ -51,14 +51,14 @@ class TestRollSite(unittest.TestCase):
         rp_context = get_cluster_context(options=opts)
         #rp_context = get_debug_test_context(is_standalone, manager_port_host, egg_port_host, transfer_port_host,
         #                                    'testing')
-        RollSiteContext("atest", {}, host_options)
+        RollSiteContext("atest", host_options, {})
 
     def test_remote(self):
         opts = {"eggroll.session.max.processors.per.node": "10"}
         rp_context = get_cluster_context(options=opts)
         #rp_context = get_debug_test_context(is_standalone, manager_port_guest, egg_port_guest, transfer_port_guest,
         #                                    'testing_guest')
-        context = RollSiteContext("atest", {}, guest_options)
+        context = RollSiteContext("atest", guest_options, {})
         _tag = "Hello2"
         rs = context.load(name="RsaIntersectTransferVariable.rsa_pubkey", tag="{}".format(_tag))
         fp = open("testA.model", 'r')
@@ -74,7 +74,7 @@ class TestRollSite(unittest.TestCase):
         rp_context = get_cluster_context(options=opts)
         #rp_context = get_debug_test_context(is_standalone, manager_port_host, egg_port_host, transfer_port_host,
         #                                    'testing')
-        context = RollSiteContext("atest", {}, host_options)
+        context = RollSiteContext("atest", host_options, {})
         _tag = "Hello2"
         rs = context.load(name="RsaIntersectTransferVariable.rsa_pubkey", tag="{}".format(_tag))
         futures = rs.pull(get_parties)
@@ -91,7 +91,7 @@ class TestRollSite(unittest.TestCase):
         rp_context = get_cluster_context(options=opts)
         #rp_context = get_debug_test_context(is_standalone, manager_port_host, egg_port_host, transfer_port_host,
         #                                    'testing')
-        RollSiteContext("atest2", {}, host_options)
+        RollSiteContext("atest2", host_options, {})
 
     def test_remote_rollpair(self):
         opts = {"eggroll.session.max.processors.per.node": "10"}
@@ -99,7 +99,7 @@ class TestRollSite(unittest.TestCase):
         #rp_context = get_debug_test_context(is_standalone, manager_port_guest, egg_port_guest, transfer_port_guest,
         #                                    'testing_guest')
         data = [("k1", "v1"), ("k2", "v2"), ("k3", "v3")]
-        context = RollSiteContext("atest2", {}, guest_options)
+        context = RollSiteContext("atest2", guest_options, {})
         rp_options = {'include_key': True}
         rp = rp_context.load("namespace", "name").put_all(data, options=rp_options)
         _tag = "Hello"
@@ -114,7 +114,7 @@ class TestRollSite(unittest.TestCase):
         rp_context = get_cluster_context(options=opts)
         #rp_context = get_debug_test_context(is_standalone, manager_port_host, egg_port_host, transfer_port_host,
         #                                    'testing')
-        context = RollSiteContext("atest2", {}, host_options)
+        context = RollSiteContext("atest2", host_options, {})
         _tag = "roll_pair_tag"
         rs = context.load(name="roll_pair_name.table", tag="{}".format(_tag))
         futures = rs.pull(get_parties)

--- a/python/eggroll/roll_site/test/test_rollsite_standalone.py
+++ b/python/eggroll/roll_site/test/test_rollsite_standalone.py
@@ -55,8 +55,8 @@ class TestRollSite(unittest.TestCase):
     def test_remote(self):
         rp_context = get_debug_test_context(is_standalone, manager_port_guest, egg_port_guest, transfer_port_guest,
                                             'testing_guest')
-        context = RollSiteContext("atest", options=guest_options,
-                                  rp_ctx=rp_context)
+        context = RollSiteContext("atest", rp_ctx=rp_context,
+                                  options=guest_options)
 
         _tag = "Hello2"
         rs = context.load(name="RsaIntersectTransferVariable.rsa_pubkey", tag="{}".format(_tag))
@@ -71,8 +71,8 @@ class TestRollSite(unittest.TestCase):
     def test_get(self):
         rp_context = get_debug_test_context(is_standalone, manager_port_host, egg_port_host, transfer_port_host,
                                             'testing')
-        context = RollSiteContext("atest", options=host_options,
-                                  rp_ctx=rp_context)
+        context = RollSiteContext("atest", rp_ctx=rp_context,
+                                  options=host_options)
         _tag = "Hello2"
         rs = context.load(name="RsaIntersectTransferVariable.rsa_pubkey", tag="{}".format(_tag))
         futures = rs.pull(get_parties)
@@ -88,8 +88,8 @@ class TestRollSite(unittest.TestCase):
         rp_context = get_debug_test_context(is_standalone, manager_port_guest, egg_port_guest, transfer_port_guest,
                                             'testing_guest')
         data = [("k1", "v1"), ("k2", "v2"), ("k3", "v3"), ("k4", "v4"), ("k5", "v5"), ("k6", "v6")]
-        context = RollSiteContext("atest2", options=guest_options,
-                                  rp_ctx=rp_context)
+        context = RollSiteContext("atest2", rp_ctx=rp_context,
+                                  options=guest_options)
         rp_options = {'include_key': True}
         rp = rp_context.load("namespace", "name").put_all(data, options=rp_options)
         _tag = "Hello"
@@ -102,8 +102,8 @@ class TestRollSite(unittest.TestCase):
     def test_get_rollpair(self):
         rp_context = get_debug_test_context(is_standalone, manager_port_host, egg_port_host, transfer_port_host,
                                             'testing')
-        context = RollSiteContext("atest2", options=host_options,
-                                  rp_ctx=rp_context)
+        context = RollSiteContext("atest2", rp_ctx=rp_context,
+                                  options=host_options)
 
         _tag = "roll_pair_tag"
         rs = context.load(name="roll_pair_name.table", tag="{}".format(_tag))

--- a/python/eggroll/roll_site/utils/roll_site_utils.py
+++ b/python/eggroll/roll_site/utils/roll_site_utils.py
@@ -14,19 +14,20 @@
 #
 #
 
-from eggroll.core.transfer_model import ErFederationHeader
+from eggroll.core.transfer_model import ErRollSiteHeader
 
 
 OBJECT_STORAGE_NAME = "__federation__"
 DELIM = "#"
 
-# TODO:1: consider moving it to ErFederationHeader class
-def create_store_name(federation_header: ErFederationHeader):
-    return DELIM.join([OBJECT_STORAGE_NAME,     # todo:0: remove this field
-                       federation_header._federation_session_id,
-                       federation_header._name,
-                       federation_header._tag,
-                       federation_header._src_role,
-                       federation_header._src_party_id,
-                       federation_header._dst_role,
-                       federation_header._dst_party_id])
+
+# TODO:1: consider moving it to ErRollSiteHeader class
+def create_store_name(roll_site_header: ErRollSiteHeader):
+    return DELIM.join([OBJECT_STORAGE_NAME,  # todo:0: remove this field
+                       roll_site_header._roll_site_session_id,
+                       roll_site_header._name,
+                       roll_site_header._tag,
+                       roll_site_header._src_role,
+                       roll_site_header._src_party_id,
+                       roll_site_header._dst_role,
+                       roll_site_header._dst_party_id])


### PR DESCRIPTION
1. Fixes issues in roll site including data transfer process, end status check etc.
2. Renames federation header to roll site header.
3. Fixes an issue in aggregate where result might be wrong.
4. Modifies aggregate / reduce interfaces to return the result value other than the result.
5. Modifies scala put batch to create command thread only when necessary instead of creating by roll pair master to reduce system overall thread number and unnecessary transfer stream.
6. Avoids a data copy in scala put batch.
7. Lots of minor enhancements.