### PR TITLE
Optimises thread numbers

### DIFF
--- a/jvm/core/main/scala/com/webank/eggroll/core/command/CommandClient.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/command/CommandClient.scala
@@ -85,7 +85,7 @@ class CommandClient(defaultEndpoint: ErEndpoint = null,
   def call[T](commandUri: CommandURI, args: RpcMessage*)(implicit tag:ClassTag[T]): T = {
     logDebug(s"[CommandClient.call, single endpoint] commandUri: ${commandUri.uriString}, endpoint: ${defaultEndpoint}")
     try {
-      val stub = CommandServiceGrpc.newBlockingStub(buildChannel(defaultEndpoint))
+      val stub = CommandServiceGrpc.newBlockingStub(GrpcClientUtils.getChannel(defaultEndpoint))
       val argBytes = args.map(x => ByteString.copyFrom(SerdesUtils.rpcMessageToBytes(x, SerdesTypes.PROTOBUF)))
       val resp = stub.call(Command.CommandRequest.newBuilder
         .setId(System.currentTimeMillis + "")
@@ -106,7 +106,7 @@ class CommandClient(defaultEndpoint: ErEndpoint = null,
     val futures = args.map {
       case (rpcMessages, endpoint) =>
         try {
-          val ch: ManagedChannel = buildChannel(endpoint)
+          val ch: ManagedChannel = GrpcClientUtils.getChannel(endpoint)
           val stub = CommandServiceGrpc.newFutureStub(ch)
           val argBytes = rpcMessages.map(x => UnsafeByteOperations.unsafeWrap(SerdesUtils.rpcMessageToBytes(x, SerdesTypes.PROTOBUF)))
           logDebug(s"[CommandClient.call, multiple endpoints] commandUri: ${commandUri.uriString}, endpoint: ${endpoint}")

--- a/jvm/core/main/scala/com/webank/eggroll/core/constant/ConfKeys.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/constant/ConfKeys.scala
@@ -58,7 +58,7 @@ object CoreConfKeys {
   val BOOTSTRAP_ROOT_SCRIPT = "eggroll.bootstrap.root.script"
   val BOOTSTRAP_SHELL = "eggroll.bootstrap.shell"
   val BOOTSTRAP_SHELL_ARGS = "eggroll.bootstrap.shell.args"
-  val CONFKEY_CORE_GRPC_CHANNEL_CACHE_EXPIRE_SEC = ErConfKey("eggroll.core.grpc.channel.cache.expire.sec", 1200)
+  val CONFKEY_CORE_GRPC_CHANNEL_CACHE_EXPIRE_SEC = ErConfKey("eggroll.core.grpc.channel.cache.expire.sec", 7200)
   val CONFKEY_CORE_GRPC_CHANNEL_CACHE_SIZE = ErConfKey("eggroll.core.grpc.channel.cache.size", 256)
   val CONFKEY_CORE_GRPC_CHANNEL_EXECUTOR_POOL_SIZE = ErConfKey("eggroll.core.grpc.channel.executor.pool.size", 128)
   val CONFKEY_CORE_GRPC_CHANNEL_FLOW_CONTROL_WINDOW = ErConfKey("eggroll.core.grpc.channel.flow.control.window", 8 << 20)

--- a/jvm/core/main/scala/com/webank/eggroll/core/transfer/GrpcUtils.scala
+++ b/jvm/core/main/scala/com/webank/eggroll/core/transfer/GrpcUtils.scala
@@ -176,7 +176,6 @@ object GrpcClientUtils extends Logging {
     }
     val builder = NettyChannelBuilder
       .forAddress(endpoint.host, endpoint.port)
-      .executor(ThreadPoolUtils.newFixedThreadPool(channelExecutorPoolSize, s"grpc-client-${endpoint.host}:${endpoint.port}"))
       .keepAliveTime(channelKeepAliveTimeSec, TimeUnit.SECONDS)
       .keepAliveTimeout(channelKeepAliveTimeoutSec, TimeUnit.SECONDS)
       .keepAliveWithoutCalls(channelKeepAliveWithoutCallsEnabled)
@@ -233,7 +232,7 @@ object GrpcClientUtils extends Logging {
   }
 
   def getChannel(endpoint: ErEndpoint,
-                 isSecureChannel: Boolean,
+                 isSecureChannel: Boolean = false,
                  options: Map[String, String] = Map.empty): ManagedChannel = {
     var result: ManagedChannel = null
     val fixedWaitTime = CoreConfKeys.CONFKEY_CORE_RETRY_DEFAULT_WAIT_TIME_MS.getWith(options).toLong

--- a/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/ProxyGrpcStubFactory.java
+++ b/jvm/roll_site/main/java/com/webank/eggroll/rollsite/factory/ProxyGrpcStubFactory.java
@@ -63,7 +63,7 @@ public class ProxyGrpcStubFactory {
     public ProxyGrpcStubFactory() {
         channelCache = CacheBuilder.newBuilder()
                 .maximumSize(100)
-                .expireAfterWrite(20, TimeUnit.MINUTES)
+                .expireAfterWrite(180, TimeUnit.MINUTES)
                 .recordStats()
                 .weakValues()
                 .removalListener(removalNotification -> {

--- a/python/eggroll/core/session.py
+++ b/python/eggroll/core/session.py
@@ -56,16 +56,13 @@ class ErSession(object):
         if "EGGROLL_DEBUG" not in os.environ:
             os.environ['EGGROLL_DEBUG'] = "0"
 
+        conf_path = options.get(CoreConfKeys.STATIC_CONF_PATH, f"{self.__eggroll_home}/conf/eggroll.properties")
+
+        L.info(f"static conf path: {conf_path}")
+        configs = configparser.ConfigParser()
+        configs.read(conf_path)
+        set_static_er_conf(configs['eggroll'])
         static_er_conf = get_static_er_conf()
-        if not static_er_conf:
-            conf_path = options.get(CoreConfKeys.STATIC_CONF_PATH, f"{self.__eggroll_home}/conf/eggroll.properties")
-            L.info(f"static conf path: {conf_path}")
-            configs = configparser.ConfigParser()
-            configs.read(conf_path)
-            set_static_er_conf(configs['eggroll'])
-            static_er_conf = get_static_er_conf()
-        else:
-            conf_path = options.get(CoreConfKeys.STATIC_CONF_PATH, f"{self.__eggroll_home}/conf/eggroll.properties")
 
         self.__options = options.copy()
         self.__options[SessionConfKeys.CONFKEY_SESSION_ID] = self.__session_id

--- a/python/eggroll/roll_pair/test/roll_pair_test_assets.py
+++ b/python/eggroll/roll_pair/test/roll_pair_test_assets.py
@@ -78,7 +78,12 @@ def get_standalone_context(options=None):
 def get_cluster_context(options=None):
     if options is None:
         options = {}
-    session = ErSession(options=options)
+
+    if 'session_id' in options:
+        session_id = options['session_id']
+    else:
+        session_id = None
+    session = ErSession(session_id=session_id, options=options)
     print(session.get_session_id())
     context = RollPairContext(session)
     return context

--- a/python/eggroll/roll_site/test/roll_site_test_asset.py
+++ b/python/eggroll/roll_site/test/roll_site_test_asset.py
@@ -116,9 +116,11 @@ def get_standalone_context(role, props_file=default_props_file):
     return rs_context
 
 
-def get_cluster_context(role, options: dict = None, props_file=default_props_file, party_id=None):
+def get_cluster_context(role, options: dict = None, props_file=default_props_file, party_id=None, session_id=None):
     if options is None:
         options = {}
+    if session_id:
+        options['session_id'] = session_id
     options[CoreConfKeys.STATIC_CONF_PATH] = props_file
     rp_context = rpta.get_cluster_context(options=options)
 


### PR DESCRIPTION
1. Removes executor in channel creation.
2. Reloads properties file in session creation.
3. Optimises parameters, both default parameters and test assets.
4. Use GrpcClientUtils for more places.



