### PR TITLE
Add ignore_errors in shutil.rmtree

### DIFF
--- a/python/eggroll/roll_pair/egg_pair.py
+++ b/python/eggroll/roll_pair/egg_pair.py
@@ -244,7 +244,7 @@ class EggPair(object):
                                 or not realpath.startswith(real_data_dir):
                             raise ValueError(f'trying to delete a dangerous path: {realpath}')
                         else:
-                            shutil.rmtree(path)
+                            shutil.rmtree(path, ignore_errors=True)
             else:
                 options = task._job._options
                 with create_adapter(task._inputs[0], options=options) as input_adapter:


### PR DESCRIPTION
We are seeing some error like:

==== detail start, at 20211220.032154.893 ====
Traceback (most recent call last):
  File "/data/projects/fate/eggroll/python/eggroll/core/utils.py", line 146, in wrapper
    return func(*args, **kw)
  File "/data/projects/fate/eggroll/python/eggroll/roll_pair/egg_pair.py", line 247, in run_task
    shutil.rmtree(path)
  File "/opt/app-root/lib64/python3.6/shutil.py", line 486, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/opt/app-root/lib64/python3.6/shutil.py", line 424, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onerror)
  File "/opt/app-root/lib64/python3.6/shutil.py", line 428, in _rmtree_safe_fd
    onerror(os.rmdir, fullname, sys.exc_info())
  File "/opt/app-root/lib64/python3.6/shutil.py", line 426, in _rmtree_safe_fd
    os.rmdir(name, dir_fd=topfd)
OSError: [Errno 39] Directory not empty: '0'

this lead to memory leak of our container, since each clean job cannot finish in eggpair, and those process just keep retrying.
So we want to set ignore error as True, to stop retrying and leaking memory

Fixes  ISSUE#xxx

Changes:

1.

2.

3.


