### PR TITLE
set computing output store type to IN_MEMORY by default

### DIFF
--- a/python/eggroll/core/conf_keys.py
+++ b/python/eggroll/core/conf_keys.py
@@ -120,7 +120,7 @@ class RollPairConfKeys(object):
     EGGROLL_ROLLPAIR_STORAGE_REPLICA_COUNT = ErConfKey("eggroll.rollpair.storage.replica.count", 1)
     EGGROLL_ROLLPAIR_STORAGE_REPLICATE_ENABLED = ErConfKey("eggroll.rollpair.storage.replicate.enabled", False)
     EGGROLL_ROLLPAIR_STORAGE_REPLICATE_TEMP_FILES = ErConfKey("eggroll.rollpair.storage.replicate.temp.files", False)
-    EGGROLL_ROLLPAIR_IN_MEMORY_OUTPUT = ErConfKey("eggroll.rollpair.inmemory_output", True)
+    EGGROLL_ROLLPAIR_IN_MEMORY_OUTPUT = ErConfKey("eggroll.rollpair.inmemory_output", False)
 
 
 class RollSiteConfKeys(object):

--- a/python/eggroll/core/conf_keys.py
+++ b/python/eggroll/core/conf_keys.py
@@ -120,6 +120,7 @@ class RollPairConfKeys(object):
     EGGROLL_ROLLPAIR_STORAGE_REPLICA_COUNT = ErConfKey("eggroll.rollpair.storage.replica.count", 1)
     EGGROLL_ROLLPAIR_STORAGE_REPLICATE_ENABLED = ErConfKey("eggroll.rollpair.storage.replicate.enabled", False)
     EGGROLL_ROLLPAIR_STORAGE_REPLICATE_TEMP_FILES = ErConfKey("eggroll.rollpair.storage.replicate.temp.files", False)
+    EGGROLL_ROLLPAIR_IN_MEMORY_OUTPUT = ErConfKey("eggroll.rollpair.inmemory_output", True)
 
 
 class RollSiteConfKeys(object):


### PR DESCRIPTION
Set computing output store type to "IN_MEMORY" maybe the better practice since 
1. it could be propeper "gc" 
2. one should explicite call `save` to store rollpari in permanent

updates:
1. add `load_store` to roll pari context
2. add `_maybe_set_output` to roll pair which using `load_store` to create an empty in memory storage
3. if output parameters not provided for `map`, `map_values`, `flat_map`, `map_partitions`, `join`, `union`, in memory storage is provided.
4.  enable using option `eggroll.rollpair.inmemory_output`