### PR TITLE
change protobuf version

### DIFF
--- a/BUILD_INFO
+++ b/BUILD_INFO
@@ -1,1 +1,1 @@
-eggroll.version=2.4.5
+eggroll.version=2.4.6

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -201,7 +201,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <eggroll.version>2.4.5</eggroll.version>
+    <eggroll.version>2.4.6</eggroll.version>
 
     <!-- Languages -->
     <code.cache.size>512m</code.cache.size>
@@ -227,7 +227,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <netty.version>4.1.63.Final</netty.version>
 <!--    <protobuf.version>3.16.1</protobuf.version>-->
-    <protobuf.version>3.21.5</protobuf.version>
+    <protobuf.version>3.21.7</protobuf.version>
     <rocksdb.version>6.8.1</rocksdb.version>
     <scalatest.version>3.0.8</scalatest.version>
     <spark.version>2.4.8</spark.version>

--- a/python/eggroll/__init__.py
+++ b/python/eggroll/__init__.py
@@ -14,4 +14,4 @@
 #  limitations under the License.
 #
 
-__version__ = "2.4.5"
+__version__ = "2.4.6"


### PR DESCRIPTION
Signed-off-by: kaideng <kaideng@kaidengdeMacBook-Pro.local>

Changes:

1.  change    version of protobuf-java to 3.21.7 to fix high risk security vulnerabilities



